### PR TITLE
Fix EndTime Serialization and GetStatus Method Syntax

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   backend:
     build: .

--- a/game/atc.go
+++ b/game/atc.go
@@ -46,7 +46,11 @@ func (g *ATCGame) StartGame() error {
 }
 
 // GetStatus will satisfy interface Game for ATC
-func (g *ATCGame) GetStatus() BaseGame {
+func (g *AtcGame) GetStatus() BaseGame {
+        if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
+                g.Base.EndTime = time.Now()
+        }
+
 	if g.Base.EndTime.IsZero() return g.Basereturn g.Base g.Base.GameState == "WON" {
 		g.Base.EndTime = time.Now()
 }

--- a/game/atc.go
+++ b/game/atc.go
@@ -39,13 +39,18 @@ func (g *ATCGame) StartGame() error {
 		Action: "CREATEGAME",
 	})
 	g.Base.SoundToPlay = "nextplayer"
+        g.Base.EndTime = time.Time{}  // Reset to zero time
+        g.Base.EndTime = time.Time{}  // Set to zero time
 
 	return nil
 }
 
 // GetStatus will satisfy interface Game for ATC
 func (g *ATCGame) GetStatus() BaseGame {
-	return g.Base
+	if g.Base.EndTime.IsZero() return g.Basereturn g.Base g.Base.GameState == "WON" {
+		g.Base.EndTime = time.Now()
+}
+return g.Base
 }
 
 // GetStatusDisplay will satisfy interface Game for game ATC
@@ -130,6 +135,8 @@ func (g *ATCGame) Rematch(h *ws.Hub) error {
 	g.Base.ActivePlayer = rg.Intn(len(g.Base.Player))
 	g.Base.ThrowRound = 1
 	g.Base.SoundToPlay = "nextplayer"
+        g.Base.EndTime = time.Time{}  // Reset to zero time
+        g.Base.EndTime = time.Time{}  // Set to zero time
 
 	for i := range g.Base.Player {
 		score := score.BaseScore{

--- a/game/atc.go
+++ b/game/atc.go
@@ -50,6 +50,11 @@ func (g *AtcGame) GetStatus() BaseGame {
         if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
                 g.Base.EndTime = time.Now()
         }
+        return g.Base
+
+        if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
+                g.Base.EndTime = time.Now()
+        }
 
 	if g.Base.EndTime.IsZero() return g.Basereturn g.Base g.Base.GameState == "WON" {
 		g.Base.EndTime = time.Now()

--- a/game/atc.go
+++ b/game/atc.go
@@ -1,242 +1,233 @@
 package game
 
 import (
-	"math/rand"
-	"time"
+        "math/rand"
+        "time"
 
-	"github.com/Kleinish/dascr-board/player"
-	"github.com/Kleinish/dascr-board/podium"
-	"github.com/Kleinish/dascr-board/score"
-	"github.com/Kleinish/dascr-board/throw"
-	"github.com/Kleinish/dascr-board/undo"
-	"github.com/Kleinish/dascr-board/utils"
-	"github.com/Kleinish/dascr-board/ws"
+        "github.com/Kleinish/dascr-board/player"
+        "github.com/Kleinish/dascr-board/podium"
+        "github.com/Kleinish/dascr-board/score"
+        "github.com/Kleinish/dascr-board/throw"
+        "github.com/Kleinish/dascr-board/undo"
+        "github.com/Kleinish/dascr-board/utils"
+        "github.com/Kleinish/dascr-board/ws"
 )
 
 // ATCGame will hold the ATC game information
 type ATCGame struct {
-	Base BaseGame
+        Base BaseGame
 }
 
 // StartGame will satisfy interface Game for ATC
 func (g *ATCGame) StartGame() error {
-	// CreateScore for each player
-	// and init empty thtrow splice
-	for i := range g.Base.Player {
-		score := score.BaseScore{
-			CurrentNumber: 1,
-		}
-		g.Base.Player[i].Score = score
-		g.Base.Player[i].ThrowRounds = make([]throw.Round, 0)
-		g.Base.Player[i].LastThrows = make([]throw.Throw, 3)
-	}
+        // CreateScore for each player
+        // and init empty thtrow splice
+        for i := range g.Base.Player {
+                score := score.BaseScore{
+                        CurrentNumber: 1,
+                }
+                g.Base.Player[i].Score = score
+                g.Base.Player[i].ThrowRounds = make([]throw.Round, 0)
+                g.Base.Player[i].LastThrows = make([]throw.Throw, 3)
+        }
 
-	g.Base.Podium = &podium.Podium{}
+        g.Base.Podium = &podium.Podium{}
 
-	g.Base.UndoLog = &undo.Log{}
-	sequence := g.Base.UndoLog.CreateSequence()
-	sequence.AddActionToSequence(undo.Action{
-		Action: "CREATEGAME",
-	})
-	g.Base.SoundToPlay = "nextplayer"
+        g.Base.UndoLog = &undo.Log{}
+        sequence := g.Base.UndoLog.CreateSequence()
+        sequence.AddActionToSequence(undo.Action{
+                Action: "CREATEGAME",
+        })
+        g.Base.SoundToPlay = "nextplayer"
         g.Base.EndTime = time.Time{}  // Reset to zero time
         g.Base.EndTime = time.Time{}  // Set to zero time
 
-	return nil
+        return nil
 }
 
 // GetStatus will satisfy interface Game for ATC
-func (g *AtcGame) GetStatus() BaseGame {
+func (g *ATCGame) GetStatus() BaseGame {
         if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
                 g.Base.EndTime = time.Now()
         }
         return g.Base
-
-        if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
-                g.Base.EndTime = time.Now()
-        }
-
-	if g.Base.EndTime.IsZero() return g.Basereturn g.Base g.Base.GameState == "WON" {
-		g.Base.EndTime = time.Now()
-}
-return g.Base
 }
 
 // GetStatusDisplay will satisfy interface Game for game ATC
 func (g *ATCGame) GetStatusDisplay() BaseGame {
-	return stripDisplay(&g.Base)
+        return stripDisplay(&g.Base)
 }
 
 // NextPlayer will satisfy interface Game for game ATC
 func (g *ATCGame) NextPlayer(h *ws.Hub) {
-	switchToNextPlayer(&g.Base, h)
+        switchToNextPlayer(&g.Base, h)
 }
 
 // RequestThrow will satisfy inteface Game for ATC
 func (g *ATCGame) RequestThrow(number, modifier int, h *ws.Hub) error {
-	sequence := g.Base.UndoLog.CreateSequence()
-	activePlayer := &g.Base.Player[g.Base.ActivePlayer]
-	previousMessage := g.Base.Message
-	previousState := g.Base.GameState
+        sequence := g.Base.UndoLog.CreateSequence()
+        activePlayer := &g.Base.Player[g.Base.ActivePlayer]
+        previousMessage := g.Base.Message
+        previousState := g.Base.GameState
 
-	// Check game state
-	if g.Base.GameState == "THROW" {
-		// check if ongoing round else create
-		checkOngoingElseCreate(activePlayer, &g.Base, sequence)
+        // Check game state
+        if g.Base.GameState == "THROW" {
+                // check if ongoing round else create
+                checkOngoingElseCreate(activePlayer, &g.Base, sequence)
 
-		// Add Throw to last round
-		throwRound := addThrowToCurrentRound(activePlayer, &g.Base, sequence, number, modifier)
+                // Add Throw to last round
+                throwRound := addThrowToCurrentRound(activePlayer, &g.Base, sequence, number, modifier)
 
-		// Score logic
-		if activePlayer.Score.CurrentNumber == number {
-			switch g.Base.Variant {
-			case "normal":
-				increaseNumberByOne(g, throwRound, activePlayer, sequence)
-				break
-			case "fast":
-				increaseNumberByMod(g, throwRound, activePlayer, sequence, modifier)
-				break
-			default:
-				break
-			}
-		}
+                // Score logic
+                if activePlayer.Score.CurrentNumber == number {
+                        switch g.Base.Variant {
+                        case "normal":
+                                increaseNumberByOne(g, throwRound, activePlayer, sequence)
+                                break
+                        case "fast":
+                                increaseNumberByMod(g, throwRound, activePlayer, sequence, modifier)
+                                break
+                        default:
+                                break
+                        }
+                }
 
-		if number == 0 || modifier == 0 {
-			g.Base.SoundToPlay = "miss"
-		}
-		// Check if 3 throws in round and close round
-		// Also set gameState and perhaps increase game.Base.ThrowRound
-		// if everyone has already thrown to this round
-		if len(throwRound.Throws) == 3 {
-			closePlayerRound(&g.Base, activePlayer, throwRound, sequence, []undo.Action{}, previousState, previousMessage)
-		}
-	}
+                if number == 0 || modifier == 0 {
+                        g.Base.SoundToPlay = "miss"
+                }
+                // Check if 3 throws in round and close round
+                // Also set gameState and perhaps increase game.Base.ThrowRound
+                // if everyone has already thrown to this round
+                if len(throwRound.Throws) == 3 {
+                        closePlayerRound(&g.Base, activePlayer, throwRound, sequence, []undo.Action{}, previousState, previousMessage)
+                }
+        }
 
-	// Set assets for Frontend
-	setFrontendAssets(activePlayer, &g.Base)
+        // Set assets for Frontend
+        setFrontendAssets(activePlayer, &g.Base)
 
-	// Update scoreboard
-	utils.WSSendUpdate(g.Base.UID, h)
+        // Update scoreboard
+        utils.WSSendUpdate(g.Base.UID, h)
 
-	return nil
+        return nil
 }
 
 // Undo will satisfy interface Game for game ATC
 func (g *ATCGame) Undo(h *ws.Hub) error {
-	if err := triggerUndo(&g.Base, h); err != nil {
-		return err
-	}
+        if err := triggerUndo(&g.Base, h); err != nil {
+                return err
+        }
 
-	return nil
+        return nil
 }
 
 // Rematch will satisfy interface Game for game ATC
 func (g *ATCGame) Rematch(h *ws.Hub) error {
-	// Init random number generator
-	s := rand.NewSource(time.Now().Unix())
-	rg := rand.New(s)
+        // Init random number generator
+        s := rand.NewSource(time.Now().Unix())
+        rg := rand.New(s)
 
-	// Reset game state
-	g.Base.Message = ""
-	g.Base.GameState = "THROW"
-	g.Base.Podium.ResetPodium()
-	g.Base.UndoLog.ClearLog()
-	g.Base.ActivePlayer = rg.Intn(len(g.Base.Player))
-	g.Base.ThrowRound = 1
-	g.Base.SoundToPlay = "nextplayer"
+        // Reset game state
+        g.Base.Message = ""
+        g.Base.GameState = "THROW"
+        g.Base.Podium.ResetPodium()
+        g.Base.UndoLog.ClearLog()
+        g.Base.ActivePlayer = rg.Intn(len(g.Base.Player))
+        g.Base.ThrowRound = 1
+        g.Base.SoundToPlay = "nextplayer"
         g.Base.EndTime = time.Time{}  // Reset to zero time
         g.Base.EndTime = time.Time{}  // Set to zero time
 
-	for i := range g.Base.Player {
-		score := score.BaseScore{
-			CurrentNumber: 1,
-		}
-		g.Base.Player[i].Score = score
-		g.Base.Player[i].ThrowRounds = make([]throw.Round, 0)
-		g.Base.Player[i].LastThrows = make([]throw.Throw, 3)
-	}
+        for i := range g.Base.Player {
+                score := score.BaseScore{
+                        CurrentNumber: 1,
+                }
+                g.Base.Player[i].Score = score
+                g.Base.Player[i].ThrowRounds = make([]throw.Round, 0)
+                g.Base.Player[i].LastThrows = make([]throw.Throw, 3)
+        }
 
-	sequence := g.Base.UndoLog.CreateSequence()
-	sequence.AddActionToSequence(undo.Action{
-		Action: "CREATEGAME",
-	})
+        sequence := g.Base.UndoLog.CreateSequence()
+        sequence.AddActionToSequence(undo.Action{
+                Action: "CREATEGAME",
+        })
 
-	// Update scoreboard
-	utils.WSSendUpdate(g.Base.UID, h)
+        // Update scoreboard
+        utils.WSSendUpdate(g.Base.UID, h)
 
-	return nil
+        return nil
 }
 
 // increases active players number by one
 // will go from 20 to 25
 // will go from 25 to win
 func increaseNumberByOne(game *ATCGame, throwRound *throw.Round, p *player.Player, sequence *undo.Sequence) {
-	previousNumberToHit := p.Score.CurrentNumber
-	if p.Score.CurrentNumber == 25 {
-		atcwin(game, throwRound, p, sequence)
-	} else if p.Score.CurrentNumber != 20 {
-		p.Score.CurrentNumber++
-	} else {
-		p.Score.CurrentNumber = 25
-	}
-	sequence.AddActionToSequence(undo.Action{
-		Action:              "ATCINCREASENUMBER",
-		GameID:              game.Base.UID,
-		Player:              p,
-		PreviousNumberToHit: previousNumberToHit,
-	})
-	game.Base.SoundToPlay = "1plib"
+        previousNumberToHit := p.Score.CurrentNumber
+        if p.Score.CurrentNumber == 25 {
+                atcwin(game, throwRound, p, sequence)
+        } else if p.Score.CurrentNumber != 20 {
+                p.Score.CurrentNumber++
+        } else {
+                p.Score.CurrentNumber = 25
+        }
+        sequence.AddActionToSequence(undo.Action{
+                Action:              "ATCINCREASENUMBER",
+                GameID:              game.Base.UID,
+                Player:              p,
+                PreviousNumberToHit: previousNumberToHit,
+        })
+        game.Base.SoundToPlay = "1plib"
 }
 
 // increase active player number += modifier
 // will go from 20 to 25
 // will go from 25 to win
 func increaseNumberByMod(game *ATCGame, throwRound *throw.Round, p *player.Player, sequence *undo.Sequence, modifier int) {
-	previousNumberToHit := p.Score.CurrentNumber
-	for i := 0; i < modifier; i++ {
-		if p.Score.CurrentNumber == 25 {
-			atcwin(game, throwRound, p, sequence)
-		} else if p.Score.CurrentNumber != 20 {
-			p.Score.CurrentNumber++
-		} else {
-			p.Score.CurrentNumber = 25
-		}
-	}
-	sequence.AddActionToSequence(undo.Action{
-		Action:              "ATCINCREASENUMBER",
-		GameID:              game.Base.UID,
-		Player:              p,
-		PreviousNumberToHit: previousNumberToHit,
-	})
-	switch modifier {
-	case 1:
-		game.Base.SoundToPlay = "1plib"
-	case 2:
-		game.Base.SoundToPlay = "2plibs"
-	case 3:
-		game.Base.SoundToPlay = "3plibs"
-	default:
-	}
+        previousNumberToHit := p.Score.CurrentNumber
+        for i := 0; i < modifier; i++ {
+                if p.Score.CurrentNumber == 25 {
+                        atcwin(game, throwRound, p, sequence)
+                } else if p.Score.CurrentNumber != 20 {
+                        p.Score.CurrentNumber++
+                } else {
+                        p.Score.CurrentNumber = 25
+                }
+        }
+        sequence.AddActionToSequence(undo.Action{
+                Action:              "ATCINCREASENUMBER",
+                GameID:              game.Base.UID,
+                Player:              p,
+                PreviousNumberToHit: previousNumberToHit,
+        })
+        switch modifier {
+        case 1:
+                game.Base.SoundToPlay = "1plib"
+        case 2:
+                game.Base.SoundToPlay = "2plibs"
+        case 3:
+                game.Base.SoundToPlay = "3plibs"
+        default:
+        }
 }
 
 // atcwin is for winning the atc game
 func atcwin(game *ATCGame, throwRound *throw.Round, activePlayer *player.Player, sequence *undo.Sequence) {
-	previousMessage := game.Base.Message
-	previousState := game.Base.GameState
+        previousMessage := game.Base.Message
+        previousState := game.Base.GameState
 
-	if game.Base.Settings.Podium {
-		// Do podium and continue game
-		doPodium(&game.Base, activePlayer, sequence)
-		return
-	}
+        if game.Base.Settings.Podium {
+                // Do podium and continue game
+                doPodium(&game.Base, activePlayer, sequence)
+                return
+        }
 
-	doWin(&game.Base)
-	throwRound.Done = true
-	sequence.AddActionToSequence(undo.Action{
-		Action:            "DOWIN",
-		GameID:            game.Base.UID,
-		PreviousGameState: previousState,
-		PreviousMessage:   previousMessage,
-		Player:            activePlayer,
-	})
+        doWin(&game.Base)
+        throwRound.Done = true
+        sequence.AddActionToSequence(undo.Action{
+                Action:            "DOWIN",
+                GameID:            game.Base.UID,
+                PreviousGameState: previousState,
+                PreviousMessage:   previousMessage,
+                Player:            activePlayer,
+        })
 }

--- a/game/common.go
+++ b/game/common.go
@@ -1,118 +1,119 @@
 package game
 
 import (
-        "math"
+	"math"
+	"time"
 
-        "github.com/Kleinish/dascr-board/player"
-        "github.com/Kleinish/dascr-board/throw"
-        "github.com/Kleinish/dascr-board/undo"
-        "github.com/Kleinish/dascr-board/utils"
-        "github.com/Kleinish/dascr-board/ws"
+	"github.com/Kleinish/dascr-board/player"
+	"github.com/Kleinish/dascr-board/throw"
+	"github.com/Kleinish/dascr-board/undo"
+	"github.com/Kleinish/dascr-board/utils"
+	"github.com/Kleinish/dascr-board/ws"
 )
 
 var (
-        soundNoOverwrite []string = []string{"reveal", "open", "close", "T17", "T18", "T19", "T20", "D25", "split"}
+	soundNoOverwrite []string = []string{"reveal", "open", "close", "T17", "T18", "T19", "T20", "D25", "split"}
 )
 
 // This will check if an ongoing throw round
 // is assosiated with the active player
 // if not it will create one
 func checkOngoingElseCreate(activePlayer *player.Player, base *BaseGame, sequence *undo.Sequence) {
-        // Check if ongoing round
-        ongoing := utils.CheckOngoingRound(activePlayer.ThrowRounds, base.ThrowRound)
-        if !ongoing {
-                // If there is no round associated with the current throw round of the game
-                // create one
-                newRound := &throw.Round{
-                        Round:  base.ThrowRound,
-                        Throws: []throw.Throw{},
-                }
-                activePlayer.ThrowRounds = append(activePlayer.ThrowRounds, *newRound)
-                sequence.AddActionToSequence(undo.Action{
-                        Action:      "CREATETHROWROUND",
-                        RoundNumber: newRound.Round,
-                        Player:      activePlayer,
-                })
-        }
+	// Check if ongoing round
+	ongoing := utils.CheckOngoingRound(activePlayer.ThrowRounds, base.ThrowRound)
+	if !ongoing {
+		// If there is no round associated with the current throw round of the game
+		// create one
+		newRound := &throw.Round{
+			Round:  base.ThrowRound,
+			Throws: []throw.Throw{},
+		}
+		activePlayer.ThrowRounds = append(activePlayer.ThrowRounds, *newRound)
+		sequence.AddActionToSequence(undo.Action{
+			Action:      "CREATETHROWROUND",
+			RoundNumber: newRound.Round,
+			Player:      activePlayer,
+		})
+	}
 }
 
 // This will add a provided throw to the last round
 // assosiated with the active player
 // It returns the throw round for further processing withing game logic
 func addThrowToCurrentRound(activePlayer *player.Player, base *BaseGame, sequence *undo.Sequence, number, modifier int) *throw.Round {
-        // Now add throw to that round or to the existing
-        throwRound := &activePlayer.ThrowRounds[base.ThrowRound-1]
-        newThrow := &throw.Throw{
-                Number:   number,
-                Modifier: modifier,
-        }
-        throwRound.Throws = append(throwRound.Throws, *newThrow)
-        sequence.AddActionToSequence(undo.Action{
-                Action:      "CREATETHROW",
-                Player:      activePlayer,
-                RoundNumber: throwRound.Round,
-        })
+	// Now add throw to that round or to the existing
+	throwRound := &activePlayer.ThrowRounds[base.ThrowRound-1]
+	newThrow := &throw.Throw{
+		Number:   number,
+		Modifier: modifier,
+	}
+	throwRound.Throws = append(throwRound.Throws, *newThrow)
+	sequence.AddActionToSequence(undo.Action{
+		Action:      "CREATETHROW",
+		Player:      activePlayer,
+		RoundNumber: throwRound.Round,
+	})
 
-        return throwRound
+	return throwRound
 }
 
 // This will check if player threw 3 darst
 // and then close the round if so
 func closePlayerRound(base *BaseGame, activePlayer *player.Player, throwRound *throw.Round, sequence *undo.Sequence, actions []undo.Action, previousState, previousMessage string) {
-        throwRound.Done = true
-        base.GameState = "NEXTPLAYER"
-        base.Message = "Remove Darts!"
-        // Check if the sound can safely be overwritten
-        // Sounds which are not supposed to be overwritten
-        // go into the var at the top (soundNoOverwrite)
-        overwrite := true
-        for _, sound := range soundNoOverwrite {
-                if sound == base.SoundToPlay {
-                        overwrite = false
-                        break
-                }
-        }
-        if overwrite {
-                base.SoundToPlay = "rounddone"
-        }
+	throwRound.Done = true
+	base.GameState = "NEXTPLAYER"
+	base.Message = "Remove Darts!"
+	// Check if the sound can safely be overwritten
+	// Sounds which are not supposed to be overwritten
+	// go into the var at the top (soundNoOverwrite)
+	overwrite := true
+	for _, sound := range soundNoOverwrite {
+		if sound == base.SoundToPlay {
+			overwrite = false
+			break
+		}
+	}
+	if overwrite {
+		base.SoundToPlay = "rounddone"
+	}
 
-        for _, a := range actions {
-                sequence.AddActionToSequence(a)
-        }
+	for _, a := range actions {
+		sequence.AddActionToSequence(a)
+	}
 
-        sequence.AddActionToSequence(undo.Action{
-                Action:            "CLOSEPLAYERTHROWROUND",
-                Player:            activePlayer,
-                RoundNumber:       throwRound.Round,
-                GameID:            base.UID,
-                PreviousGameState: previousState,
-                PreviousMessage:   previousMessage,
-        })
+	sequence.AddActionToSequence(undo.Action{
+		Action:            "CLOSEPLAYERTHROWROUND",
+		Player:            activePlayer,
+		RoundNumber:       throwRound.Round,
+		GameID:            base.UID,
+		PreviousGameState: previousState,
+		PreviousMessage:   previousMessage,
+	})
 }
 
 // This will be used by setFrontendAssets
 // It calculates player average and total throw count
 func calculateAverageAndTotalThrowCount(player *player.Player) *player.Player {
-        // Set average
-        allTotalThrowCount := 0
-        totalSumCount := 0
-        divider := float64(0)
-        for _, rnd := range player.ThrowRounds {
-                for _, thr := range rnd.Throws {
-                        totalSumCount += thr.Number * thr.Modifier
-                        divider += float64(1 / 3.0)
-                        allTotalThrowCount++
-                }
-        }
-        avg := float64(totalSumCount) / divider
-        avg = math.Round(avg*100) / 100
-        if math.IsNaN(avg) {
-                avg = 0
-        }
-        player.Average = avg
-        player.TotalThrowCount = allTotalThrowCount
+	// Set average
+	allTotalThrowCount := 0
+	totalSumCount := 0
+	divider := float64(0)
+	for _, rnd := range player.ThrowRounds {
+		for _, thr := range rnd.Throws {
+			totalSumCount += thr.Number * thr.Modifier
+			divider += float64(1 / 3.0)
+			allTotalThrowCount++
+		}
+	}
+	avg := float64(totalSumCount) / divider
+	avg = math.Round(avg*100) / 100
+	if math.IsNaN(avg) {
+		avg = 0
+	}
+	player.Average = avg
+	player.TotalThrowCount = allTotalThrowCount
 
-        return player
+	return player
 }
 
 // This will be used by setFrontendAssets
@@ -120,337 +121,337 @@ func calculateAverageAndTotalThrowCount(player *player.Player) *player.Player {
 // To the last 3 throws of current throw round
 // Ommiting empty throws
 func getLastThreeThrows(player *player.Player, base *BaseGame) *player.Player {
-        // Set last 3 throws
-        // and sum of it
-        player.LastThrows = make([]throw.Throw, 0)
-        lastThreeSum := 0
-        if len(player.ThrowRounds) > 0 {
-                if len(player.ThrowRounds[len(player.ThrowRounds)-1].Throws) != 0 {
-                        for _, thr := range player.ThrowRounds[len(player.ThrowRounds)-1].Throws {
-                                player.LastThrows = append(player.LastThrows, thr)
-                                lastThreeSum += thr.Number * thr.Modifier
-                        }
-                        player.ThrowSum = lastThreeSum
-                }
-        } else {
-                player.LastThrows = make([]throw.Throw, 3)
-        }
+	// Set last 3 throws
+	// and sum of it
+	player.LastThrows = make([]throw.Throw, 0)
+	lastThreeSum := 0
+	if len(player.ThrowRounds) > 0 {
+		if len(player.ThrowRounds[len(player.ThrowRounds)-1].Throws) != 0 {
+			for _, thr := range player.ThrowRounds[len(player.ThrowRounds)-1].Throws {
+				player.LastThrows = append(player.LastThrows, thr)
+				lastThreeSum += thr.Number * thr.Modifier
+			}
+			player.ThrowSum = lastThreeSum
+		}
+	} else {
+		player.LastThrows = make([]throw.Throw, 3)
+	}
 
-        return player
+	return player
 }
 
 // This will take care of the stats to display at frontend
 func setFrontendAssets(player *player.Player, base *BaseGame) {
-        player = calculateAverageAndTotalThrowCount(player)
-        getLastThreeThrows(player, base)
+	player = calculateAverageAndTotalThrowCount(player)
+	getLastThreeThrows(player, base)
 }
 
 // This will set game state for podium case
 // Placement of player on podium
 func doPodium(base *BaseGame, activePlayer *player.Player, sequence *undo.Sequence) {
-        previousMessage := base.Message
-        previousState := base.GameState
-        playerLeft := len(base.Player) - base.Podium.GetPodiumLength()
+	previousMessage := base.Message
+	previousState := base.GameState
+	playerLeft := len(base.Player) - base.Podium.GetPodiumLength()
 
-        // More than 2 player left to go to the podium
-        if playerLeft > 2 {
-                // Push active players uid to podium
-                base.Podium.AddPlayerToPodium(activePlayer)
-                base.GameState = "NEXTPLAYERWON"
-                base.Message = "Next Winner!"
-                base.SoundToPlay = "win"
+	// More than 2 player left to go to the podium
+	if playerLeft > 2 {
+		// Push active players uid to podium
+		base.Podium.AddPlayerToPodium(activePlayer)
+		base.GameState = "NEXTPLAYERWON"
+		base.Message = "Next Winner!"
+		base.SoundToPlay = "win"
 
-                if base.Podium.GetPodiumLength() == 1 {
-                        base.Message = "Winner!"
-                }
+		if base.Podium.GetPodiumLength() == 1 {
+			base.Message = "Winner!"
+		}
 
-                sequence.AddActionToSequence(undo.Action{
-                        Action:            "DOPODIUM",
-                        Player:            activePlayer,
-                        PreviousGameState: previousState,
-                        PreviousMessage:   previousMessage,
-                        GameID:            base.UID,
-                })
-                return
-        }
+		sequence.AddActionToSequence(undo.Action{
+			Action:            "DOPODIUM",
+			Player:            activePlayer,
+			PreviousGameState: previousState,
+			PreviousMessage:   previousMessage,
+			GameID:            base.UID,
+		})
+		return
+	}
 
-        // Otherwise exactly 2 left
-        base.Podium.AddPlayerToPodium(activePlayer)
-        sequence.AddActionToSequence(undo.Action{
-                Action:            "DOPODIUM",
-                Player:            activePlayer,
-                PreviousGameState: previousState,
-                PreviousMessage:   previousMessage,
-                GameID:            base.UID,
-        })
-        for i := range base.Player {
-                var contained = false
-                // When player UID is not in base.Podium
-                podium := *base.Podium.GetPodium()
-                for j := range podium {
-                        if base.Player[i].UID == podium[j].Player.UID {
-                                contained = true
-                        }
+	// Otherwise exactly 2 left
+	base.Podium.AddPlayerToPodium(activePlayer)
+	sequence.AddActionToSequence(undo.Action{
+		Action:            "DOPODIUM",
+		Player:            activePlayer,
+		PreviousGameState: previousState,
+		PreviousMessage:   previousMessage,
+		GameID:            base.UID,
+	})
+	for i := range base.Player {
+		var contained = false
+		// When player UID is not in base.Podium
+		podium := *base.Podium.GetPodium()
+		for j := range podium {
+			if base.Player[i].UID == podium[j].Player.UID {
+				contained = true
+			}
 
-                }
+		}
 
-                if !contained {
-                        base.Podium.AddPlayerToPodium(&base.Player[i])
-                        sequence.AddActionToSequence(undo.Action{
-                                Action:            "DOPODIUM",
-                                Player:            activePlayer,
-                                PreviousGameState: previousState,
-                                PreviousMessage:   previousMessage,
-                                GameID:            base.UID,
-                        })
+		if !contained {
+			base.Podium.AddPlayerToPodium(&base.Player[i])
+			sequence.AddActionToSequence(undo.Action{
+				Action:            "DOPODIUM",
+				Player:            activePlayer,
+				PreviousGameState: previousState,
+				PreviousMessage:   previousMessage,
+				GameID:            base.UID,
+			})
 
-                        doWin(base)
-                        throwRound := &activePlayer.ThrowRounds[base.ThrowRound-1]
-                        throwRound.Done = true
-                        activePlayer.Score.Score = 0
-                        activePlayer.Score.ParkScore = 0
+			doWin(base)
+			throwRound := &activePlayer.ThrowRounds[base.ThrowRound-1]
+			throwRound.Done = true
+			activePlayer.Score.Score = 0
+			activePlayer.Score.ParkScore = 0
 
-                        previousScore := activePlayer.Score.Score
-                        previousParkScore := activePlayer.Score.ParkScore
-                        sequence.AddActionToSequence(undo.Action{
-                                Action:            "DOWIN",
-                                GameID:            base.UID,
-                                PreviousGameState: previousState,
-                                PreviousMessage:   previousMessage,
-                                Player:            activePlayer,
-                                PreviousScore:     previousScore,
-                                PreviousParkScore: previousParkScore,
-                        })
+			previousScore := activePlayer.Score.Score
+			previousParkScore := activePlayer.Score.ParkScore
+			sequence.AddActionToSequence(undo.Action{
+				Action:            "DOWIN",
+				GameID:            base.UID,
+				PreviousGameState: previousState,
+				PreviousMessage:   previousMessage,
+				Player:            activePlayer,
+				PreviousScore:     previousScore,
+				PreviousParkScore: previousParkScore,
+			})
 
-                        return
-                }
-        }
+			return
+		}
+	}
 }
 
 // This will set game state for win case
 func doWin(base *BaseGame) {
-        // Set game state
-        base.GameState = "WON"
-        base.Message = "Game shot!"
-        base.SoundToPlay = "win"
-        base.EndTime = time.Now()  // Set end time when game is won
+	// Set game state
+	base.GameState = "WON"
+	base.Message = "Game shot!"
+	base.SoundToPlay = "win"
+	base.EndTime = time.Now() // Set end time when game is won
 }
 
 // This will strip response for Display function for FrontEnd
 // To minimize traffic size
 func stripDisplay(base *BaseGame) BaseGame {
-        var returnBase BaseGame
-        var returnPlayer = make([]player.Player, 0)
-        returnBase = *base
+	var returnBase BaseGame
+	var returnPlayer = make([]player.Player, 0)
+	returnBase = *base
 
-        for _, p := range returnBase.Player {
-                var tr = make([]throw.Round, 0)
-                p.ThrowRounds = tr
-                returnPlayer = append(returnPlayer, p)
-        }
+	for _, p := range returnBase.Player {
+		var tr = make([]throw.Round, 0)
+		p.ThrowRounds = tr
+		returnPlayer = append(returnPlayer, p)
+	}
 
-        returnBase.UndoLog = nil
-        returnBase.Player = returnPlayer
+	returnBase.UndoLog = nil
+	returnBase.Player = returnPlayer
 
-        return returnBase
+	return returnBase
 }
 
 // This will fill the players current throw round with 0s
 // for the case someone pressed nextPlayer before
 // entering all 3 throws
 func fillWithZeros(base *BaseGame, sequence *undo.Sequence, previousState, PreviousMessage string) {
-        // fill empty throws of active player with 0
-        // before switching to next player
-        activePlayer := &base.Player[base.ActivePlayer]
-        // Check if ongoing round
-        checkOngoingElseCreate(activePlayer, base, sequence)
+	// fill empty throws of active player with 0
+	// before switching to next player
+	activePlayer := &base.Player[base.ActivePlayer]
+	// Check if ongoing round
+	checkOngoingElseCreate(activePlayer, base, sequence)
 
-        currentThrowRound := &activePlayer.ThrowRounds[base.ThrowRound-1]
-        count := 3 - len(currentThrowRound.Throws)
-        if count != 0 {
-                for i := 0; i < count; i++ {
-                        newThrow := &throw.Throw{
-                                Number:   0,
-                                Modifier: 1,
-                        }
-                        currentThrowRound.Throws = append(currentThrowRound.Throws, *newThrow)
-                        sequence.AddActionToSequence(undo.Action{
-                                Action:      "CREATETHROW",
-                                Player:      activePlayer,
-                                RoundNumber: currentThrowRound.Round,
-                        })
+	currentThrowRound := &activePlayer.ThrowRounds[base.ThrowRound-1]
+	count := 3 - len(currentThrowRound.Throws)
+	if count != 0 {
+		for i := 0; i < count; i++ {
+			newThrow := &throw.Throw{
+				Number:   0,
+				Modifier: 1,
+			}
+			currentThrowRound.Throws = append(currentThrowRound.Throws, *newThrow)
+			sequence.AddActionToSequence(undo.Action{
+				Action:      "CREATETHROW",
+				Player:      activePlayer,
+				RoundNumber: currentThrowRound.Round,
+			})
 
-                }
-                currentThrowRound.Done = true
+		}
+		currentThrowRound.Done = true
 
-                // When X01 we need to set new parkScore
-                if base.Game == "x01" {
-                        activePlayer.Score.ParkScore = activePlayer.Score.Score
-                        previousParkScore := activePlayer.Score.ParkScore
-                        previousScore := activePlayer.Score.Score
-                        previousAverage := activePlayer.Average
-                        previousThrowSum := activePlayer.ThrowSum
-                        previousLastThree := activePlayer.LastThrows
+		// When X01 we need to set new parkScore
+		if base.Game == "x01" {
+			activePlayer.Score.ParkScore = activePlayer.Score.Score
+			previousParkScore := activePlayer.Score.ParkScore
+			previousScore := activePlayer.Score.Score
+			previousAverage := activePlayer.Average
+			previousThrowSum := activePlayer.ThrowSum
+			previousLastThree := activePlayer.LastThrows
 
-                        sequence.AddActionToSequence(undo.Action{
-                                Action:            "UPDATESCOREANDPARK",
-                                Player:            activePlayer,
-                                PreviousScore:     previousScore,
-                                PreviousParkScore: previousParkScore,
-                                PreviousAverage:   previousAverage,
-                                PreviousThrowSum:  previousThrowSum,
-                                PreviousLastThree: previousLastThree,
-                        })
-                }
+			sequence.AddActionToSequence(undo.Action{
+				Action:            "UPDATESCOREANDPARK",
+				Player:            activePlayer,
+				PreviousScore:     previousScore,
+				PreviousParkScore: previousParkScore,
+				PreviousAverage:   previousAverage,
+				PreviousThrowSum:  previousThrowSum,
+				PreviousLastThree: previousLastThree,
+			})
+		}
 
-                sequence.AddActionToSequence(undo.Action{
-                        Action:            "CLOSEPLAYERTHROWROUND",
-                        Player:            activePlayer,
-                        RoundNumber:       currentThrowRound.Round,
-                        GameID:            base.UID,
-                        PreviousGameState: previousState,
-                        PreviousMessage:   PreviousMessage,
-                })
-        }
+		sequence.AddActionToSequence(undo.Action{
+			Action:            "CLOSEPLAYERTHROWROUND",
+			Player:            activePlayer,
+			RoundNumber:       currentThrowRound.Round,
+			GameID:            base.UID,
+			PreviousGameState: previousState,
+			PreviousMessage:   PreviousMessage,
+		})
+	}
 
 }
 
 // This will switch to next player
 func switchToNextPlayer(base *BaseGame, h *ws.Hub) {
-        sequence := base.UndoLog.CreateSequence()
-        previousPlayerIndex := base.ActivePlayer
-        previousState := base.GameState
-        previousMessage := base.Message
+	sequence := base.UndoLog.CreateSequence()
+	previousPlayerIndex := base.ActivePlayer
+	previousState := base.GameState
+	previousMessage := base.Message
 
-        // Switch to next player
-        if base.GameState != "WON" {
-                activePlayer := &base.Player[base.ActivePlayer]
-                fillWithZeros(base, sequence, previousState, previousMessage)
+	// Switch to next player
+	if base.GameState != "WON" {
+		activePlayer := &base.Player[base.ActivePlayer]
+		fillWithZeros(base, sequence, previousState, previousMessage)
 
-                // Switch player
-                base.ActivePlayer = utils.ChooseNextPlayer(base.Player, base.ActivePlayer, base.Podium.GetPodium())
-                // Reset gamestate
-                base.GameState = "THROW"
-                base.Message = "-"
-                base.SoundToPlay = "nextplayer"
+		// Switch player
+		base.ActivePlayer = utils.ChooseNextPlayer(base.Player, base.ActivePlayer, base.Podium.GetPodium())
+		// Reset gamestate
+		base.GameState = "THROW"
+		base.Message = "-"
+		base.SoundToPlay = "nextplayer"
 
-                sequence.AddActionToSequence(undo.Action{
-                        Action:              "NEXTPLAYER",
-                        PreviousPlayerIndex: previousPlayerIndex,
-                        GameID:              base.UID,
-                })
+		sequence.AddActionToSequence(undo.Action{
+			Action:              "NEXTPLAYER",
+			PreviousPlayerIndex: previousPlayerIndex,
+			GameID:              base.UID,
+		})
 
-                // Set assets for Frontend
-                setFrontendAssets(activePlayer, base)
+		// Set assets for Frontend
+		setFrontendAssets(activePlayer, base)
 
-                // Update scoreboard
-                utils.WSSendUpdate(base.UID, h)
+		// Update scoreboard
+		utils.WSSendUpdate(base.UID, h)
 
-                // Check if throw round done by all players and increase
-                checkRoundDone(base, sequence)
-        }
+		// Check if throw round done by all players and increase
+		checkRoundDone(base, sequence)
+	}
 }
 
 // This will check if the round is done and increase overall
 // Throw round
 func checkRoundDone(base *BaseGame, sequence *undo.Sequence) {
-        // Check if to increase game.ThrowRound
-        if roundDone := utils.CheckRoundDone(base.Player, base.ThrowRound, base.Podium.GetPodium()); roundDone {
-                base.ThrowRound++
-                sequence.AddActionToSequence(undo.Action{
-                        Action: "INCREASETHROWROUND",
-                        GameID: base.UID,
-                })
-        }
+	// Check if to increase game.ThrowRound
+	if roundDone := utils.CheckRoundDone(base.Player, base.ThrowRound, base.Podium.GetPodium()); roundDone {
+		base.ThrowRound++
+		sequence.AddActionToSequence(undo.Action{
+			Action: "INCREASETHROWROUND",
+			GameID: base.UID,
+		})
+	}
 }
 
 // This will trigger undo
 func triggerUndo(base *BaseGame, h *ws.Hub) error {
-        // Check length and do not remove "CREATEGAME"
-        if len(*base.UndoLog) > 1 {
-                sequence, err := base.UndoLog.GetLastSequence()
-                if err != nil {
-                        return err
-                }
+	// Check length and do not remove "CREATEGAME"
+	if len(*base.UndoLog) > 1 {
+		sequence, err := base.UndoLog.GetLastSequence()
+		if err != nil {
+			return err
+		}
 
-                for _, a := range sequence.Action {
-                        if a.Action == "CREATETHROWROUND" {
-                                // look if there is CREATETHROWROUND in sequence
-                                // if so resort and put it last as otherwise
-                                // undo will be rendered unusable
+		for _, a := range sequence.Action {
+			if a.Action == "CREATETHROWROUND" {
+				// look if there is CREATETHROWROUND in sequence
+				// if so resort and put it last as otherwise
+				// undo will be rendered unusable
 
-                                // park CREATETHROWROUND
-                                parkAction := sequence.Action[0]
+				// park CREATETHROWROUND
+				parkAction := sequence.Action[0]
 
-                                // remove CREATETHROWROUND from sequence
-                                sequence.Action = sequence.Action[1:]
+				// remove CREATETHROWROUND from sequence
+				sequence.Action = sequence.Action[1:]
 
-                                // add CREATETHROWROUND at the end
-                                sequence.Action = append(sequence.Action, parkAction)
+				// add CREATETHROWROUND at the end
+				sequence.Action = append(sequence.Action, parkAction)
 
-                                break
-                        }
-                }
+				break
+			}
+		}
 
-                for _, a := range sequence.Action {
-                        switch a.Action {
-                        case "CREATETHROWROUND":
-                                UndoCreateThrowRound(a)
-                        case "CREATETHROW":
-                                UndoCreateThrow(a)
-                        case "DOWIN":
-                                UndoWin(a, base)
-                        case "DOPODIUM":
-                                UndoDoPodium(a, base)
-                        case "NEXTPLAYER":
-                                UndoNextPlayer(a, base)
-                        case "CLOSEPLAYERTHROWROUND":
-                                UndoClosePlayerThrowRound(a, base)
-                        case "INCREASETHROWROUND":
-                                UndoIncreaseThrowRound(a, base)
-                        // X01
-                        case "UPDATESCORE":
-                                UndoScore(a)
-                        case "UPDATESCOREANDPARK":
-                                UndoScoreAndPark(a)
-                        case "X01BUST":
-                                UndoBustAndWin(a, base)
-                        // Cricket
-                        case "REVEALNUMBER":
-                                UndoRevealNumber(a, base)
-                        case "INCREASEHITCOUNT":
-                                UndoIncreaseHitCount(a)
-                        case "CLOSEPLAYERNUMBER":
-                                UndoClosePlayerNumber(a)
-                        case "CLOSECONTROLLERNUMBER":
-                                UndoCloseControllerNumber(a, base)
-                        case "GAINPOINTS":
-                                UndoGainPoints(a)
-                        // ATC
-                        case "ATCINCREASENUMBER":
-                                UndoATCIncreaseNumber(a)
-                        // Split
-                        case "UPDATESPLITSCORE":
-                                UndoUpdateSplitScore(a)
-                        default:
-                                break
-                        }
-                }
+		for _, a := range sequence.Action {
+			switch a.Action {
+			case "CREATETHROWROUND":
+				UndoCreateThrowRound(a)
+			case "CREATETHROW":
+				UndoCreateThrow(a)
+			case "DOWIN":
+				UndoWin(a, base)
+			case "DOPODIUM":
+				UndoDoPodium(a, base)
+			case "NEXTPLAYER":
+				UndoNextPlayer(a, base)
+			case "CLOSEPLAYERTHROWROUND":
+				UndoClosePlayerThrowRound(a, base)
+			case "INCREASETHROWROUND":
+				UndoIncreaseThrowRound(a, base)
+			// X01
+			case "UPDATESCORE":
+				UndoScore(a)
+			case "UPDATESCOREANDPARK":
+				UndoScoreAndPark(a)
+			case "X01BUST":
+				UndoBustAndWin(a, base)
+			// Cricket
+			case "REVEALNUMBER":
+				UndoRevealNumber(a, base)
+			case "INCREASEHITCOUNT":
+				UndoIncreaseHitCount(a)
+			case "CLOSEPLAYERNUMBER":
+				UndoClosePlayerNumber(a)
+			case "CLOSECONTROLLERNUMBER":
+				UndoCloseControllerNumber(a, base)
+			case "GAINPOINTS":
+				UndoGainPoints(a)
+			// ATC
+			case "ATCINCREASENUMBER":
+				UndoATCIncreaseNumber(a)
+			// Split
+			case "UPDATESPLITSCORE":
+				UndoUpdateSplitScore(a)
+			default:
+				break
+			}
+		}
 
-                // Remove sequence from undo log
-                base.UndoLog.RemoveLastSequence()
+		// Remove sequence from undo log
+		base.UndoLog.RemoveLastSequence()
 
-                // reset assets
-                setFrontendAssets(&base.Player[base.ActivePlayer], base)
+		// reset assets
+		setFrontendAssets(&base.Player[base.ActivePlayer], base)
 
-                // Update trigger via hub
-                message := ws.Message{
-                        Room: base.UID,
-                        Data: []byte("update"),
-                }
+		// Update trigger via hub
+		message := ws.Message{
+			Room: base.UID,
+			Data: []byte("update"),
+		}
 
-                h.Broadcast <- message
-        }
+		h.Broadcast <- message
+	}
 
-        return nil
+	return nil
 }

--- a/game/common.go
+++ b/game/common.go
@@ -1,118 +1,118 @@
 package game
 
 import (
-	"math"
+        "math"
 
-	"github.com/Kleinish/dascr-board/player"
-	"github.com/Kleinish/dascr-board/throw"
-	"github.com/Kleinish/dascr-board/undo"
-	"github.com/Kleinish/dascr-board/utils"
-	"github.com/Kleinish/dascr-board/ws"
+        "github.com/Kleinish/dascr-board/player"
+        "github.com/Kleinish/dascr-board/throw"
+        "github.com/Kleinish/dascr-board/undo"
+        "github.com/Kleinish/dascr-board/utils"
+        "github.com/Kleinish/dascr-board/ws"
 )
 
 var (
-	soundNoOverwrite []string = []string{"reveal", "open", "close", "T17", "T18", "T19", "T20", "D25", "split"}
+        soundNoOverwrite []string = []string{"reveal", "open", "close", "T17", "T18", "T19", "T20", "D25", "split"}
 )
 
 // This will check if an ongoing throw round
 // is assosiated with the active player
 // if not it will create one
 func checkOngoingElseCreate(activePlayer *player.Player, base *BaseGame, sequence *undo.Sequence) {
-	// Check if ongoing round
-	ongoing := utils.CheckOngoingRound(activePlayer.ThrowRounds, base.ThrowRound)
-	if !ongoing {
-		// If there is no round associated with the current throw round of the game
-		// create one
-		newRound := &throw.Round{
-			Round:  base.ThrowRound,
-			Throws: []throw.Throw{},
-		}
-		activePlayer.ThrowRounds = append(activePlayer.ThrowRounds, *newRound)
-		sequence.AddActionToSequence(undo.Action{
-			Action:      "CREATETHROWROUND",
-			RoundNumber: newRound.Round,
-			Player:      activePlayer,
-		})
-	}
+        // Check if ongoing round
+        ongoing := utils.CheckOngoingRound(activePlayer.ThrowRounds, base.ThrowRound)
+        if !ongoing {
+                // If there is no round associated with the current throw round of the game
+                // create one
+                newRound := &throw.Round{
+                        Round:  base.ThrowRound,
+                        Throws: []throw.Throw{},
+                }
+                activePlayer.ThrowRounds = append(activePlayer.ThrowRounds, *newRound)
+                sequence.AddActionToSequence(undo.Action{
+                        Action:      "CREATETHROWROUND",
+                        RoundNumber: newRound.Round,
+                        Player:      activePlayer,
+                })
+        }
 }
 
 // This will add a provided throw to the last round
 // assosiated with the active player
 // It returns the throw round for further processing withing game logic
 func addThrowToCurrentRound(activePlayer *player.Player, base *BaseGame, sequence *undo.Sequence, number, modifier int) *throw.Round {
-	// Now add throw to that round or to the existing
-	throwRound := &activePlayer.ThrowRounds[base.ThrowRound-1]
-	newThrow := &throw.Throw{
-		Number:   number,
-		Modifier: modifier,
-	}
-	throwRound.Throws = append(throwRound.Throws, *newThrow)
-	sequence.AddActionToSequence(undo.Action{
-		Action:      "CREATETHROW",
-		Player:      activePlayer,
-		RoundNumber: throwRound.Round,
-	})
+        // Now add throw to that round or to the existing
+        throwRound := &activePlayer.ThrowRounds[base.ThrowRound-1]
+        newThrow := &throw.Throw{
+                Number:   number,
+                Modifier: modifier,
+        }
+        throwRound.Throws = append(throwRound.Throws, *newThrow)
+        sequence.AddActionToSequence(undo.Action{
+                Action:      "CREATETHROW",
+                Player:      activePlayer,
+                RoundNumber: throwRound.Round,
+        })
 
-	return throwRound
+        return throwRound
 }
 
 // This will check if player threw 3 darst
 // and then close the round if so
 func closePlayerRound(base *BaseGame, activePlayer *player.Player, throwRound *throw.Round, sequence *undo.Sequence, actions []undo.Action, previousState, previousMessage string) {
-	throwRound.Done = true
-	base.GameState = "NEXTPLAYER"
-	base.Message = "Remove Darts!"
-	// Check if the sound can safely be overwritten
-	// Sounds which are not supposed to be overwritten
-	// go into the var at the top (soundNoOverwrite)
-	overwrite := true
-	for _, sound := range soundNoOverwrite {
-		if sound == base.SoundToPlay {
-			overwrite = false
-			break
-		}
-	}
-	if overwrite {
-		base.SoundToPlay = "rounddone"
-	}
+        throwRound.Done = true
+        base.GameState = "NEXTPLAYER"
+        base.Message = "Remove Darts!"
+        // Check if the sound can safely be overwritten
+        // Sounds which are not supposed to be overwritten
+        // go into the var at the top (soundNoOverwrite)
+        overwrite := true
+        for _, sound := range soundNoOverwrite {
+                if sound == base.SoundToPlay {
+                        overwrite = false
+                        break
+                }
+        }
+        if overwrite {
+                base.SoundToPlay = "rounddone"
+        }
 
-	for _, a := range actions {
-		sequence.AddActionToSequence(a)
-	}
+        for _, a := range actions {
+                sequence.AddActionToSequence(a)
+        }
 
-	sequence.AddActionToSequence(undo.Action{
-		Action:            "CLOSEPLAYERTHROWROUND",
-		Player:            activePlayer,
-		RoundNumber:       throwRound.Round,
-		GameID:            base.UID,
-		PreviousGameState: previousState,
-		PreviousMessage:   previousMessage,
-	})
+        sequence.AddActionToSequence(undo.Action{
+                Action:            "CLOSEPLAYERTHROWROUND",
+                Player:            activePlayer,
+                RoundNumber:       throwRound.Round,
+                GameID:            base.UID,
+                PreviousGameState: previousState,
+                PreviousMessage:   previousMessage,
+        })
 }
 
 // This will be used by setFrontendAssets
 // It calculates player average and total throw count
 func calculateAverageAndTotalThrowCount(player *player.Player) *player.Player {
-	// Set average
-	allTotalThrowCount := 0
-	totalSumCount := 0
-	divider := float64(0)
-	for _, rnd := range player.ThrowRounds {
-		for _, thr := range rnd.Throws {
-			totalSumCount += thr.Number * thr.Modifier
-			divider += float64(1 / 3.0)
-			allTotalThrowCount++
-		}
-	}
-	avg := float64(totalSumCount) / divider
-	avg = math.Round(avg*100) / 100
-	if math.IsNaN(avg) {
-		avg = 0
-	}
-	player.Average = avg
-	player.TotalThrowCount = allTotalThrowCount
+        // Set average
+        allTotalThrowCount := 0
+        totalSumCount := 0
+        divider := float64(0)
+        for _, rnd := range player.ThrowRounds {
+                for _, thr := range rnd.Throws {
+                        totalSumCount += thr.Number * thr.Modifier
+                        divider += float64(1 / 3.0)
+                        allTotalThrowCount++
+                }
+        }
+        avg := float64(totalSumCount) / divider
+        avg = math.Round(avg*100) / 100
+        if math.IsNaN(avg) {
+                avg = 0
+        }
+        player.Average = avg
+        player.TotalThrowCount = allTotalThrowCount
 
-	return player
+        return player
 }
 
 // This will be used by setFrontendAssets
@@ -120,336 +120,337 @@ func calculateAverageAndTotalThrowCount(player *player.Player) *player.Player {
 // To the last 3 throws of current throw round
 // Ommiting empty throws
 func getLastThreeThrows(player *player.Player, base *BaseGame) *player.Player {
-	// Set last 3 throws
-	// and sum of it
-	player.LastThrows = make([]throw.Throw, 0)
-	lastThreeSum := 0
-	if len(player.ThrowRounds) > 0 {
-		if len(player.ThrowRounds[len(player.ThrowRounds)-1].Throws) != 0 {
-			for _, thr := range player.ThrowRounds[len(player.ThrowRounds)-1].Throws {
-				player.LastThrows = append(player.LastThrows, thr)
-				lastThreeSum += thr.Number * thr.Modifier
-			}
-			player.ThrowSum = lastThreeSum
-		}
-	} else {
-		player.LastThrows = make([]throw.Throw, 3)
-	}
+        // Set last 3 throws
+        // and sum of it
+        player.LastThrows = make([]throw.Throw, 0)
+        lastThreeSum := 0
+        if len(player.ThrowRounds) > 0 {
+                if len(player.ThrowRounds[len(player.ThrowRounds)-1].Throws) != 0 {
+                        for _, thr := range player.ThrowRounds[len(player.ThrowRounds)-1].Throws {
+                                player.LastThrows = append(player.LastThrows, thr)
+                                lastThreeSum += thr.Number * thr.Modifier
+                        }
+                        player.ThrowSum = lastThreeSum
+                }
+        } else {
+                player.LastThrows = make([]throw.Throw, 3)
+        }
 
-	return player
+        return player
 }
 
 // This will take care of the stats to display at frontend
 func setFrontendAssets(player *player.Player, base *BaseGame) {
-	player = calculateAverageAndTotalThrowCount(player)
-	getLastThreeThrows(player, base)
+        player = calculateAverageAndTotalThrowCount(player)
+        getLastThreeThrows(player, base)
 }
 
 // This will set game state for podium case
 // Placement of player on podium
 func doPodium(base *BaseGame, activePlayer *player.Player, sequence *undo.Sequence) {
-	previousMessage := base.Message
-	previousState := base.GameState
-	playerLeft := len(base.Player) - base.Podium.GetPodiumLength()
+        previousMessage := base.Message
+        previousState := base.GameState
+        playerLeft := len(base.Player) - base.Podium.GetPodiumLength()
 
-	// More than 2 player left to go to the podium
-	if playerLeft > 2 {
-		// Push active players uid to podium
-		base.Podium.AddPlayerToPodium(activePlayer)
-		base.GameState = "NEXTPLAYERWON"
-		base.Message = "Next Winner!"
-		base.SoundToPlay = "win"
+        // More than 2 player left to go to the podium
+        if playerLeft > 2 {
+                // Push active players uid to podium
+                base.Podium.AddPlayerToPodium(activePlayer)
+                base.GameState = "NEXTPLAYERWON"
+                base.Message = "Next Winner!"
+                base.SoundToPlay = "win"
 
-		if base.Podium.GetPodiumLength() == 1 {
-			base.Message = "Winner!"
-		}
+                if base.Podium.GetPodiumLength() == 1 {
+                        base.Message = "Winner!"
+                }
 
-		sequence.AddActionToSequence(undo.Action{
-			Action:            "DOPODIUM",
-			Player:            activePlayer,
-			PreviousGameState: previousState,
-			PreviousMessage:   previousMessage,
-			GameID:            base.UID,
-		})
-		return
-	}
+                sequence.AddActionToSequence(undo.Action{
+                        Action:            "DOPODIUM",
+                        Player:            activePlayer,
+                        PreviousGameState: previousState,
+                        PreviousMessage:   previousMessage,
+                        GameID:            base.UID,
+                })
+                return
+        }
 
-	// Otherwise exactly 2 left
-	base.Podium.AddPlayerToPodium(activePlayer)
-	sequence.AddActionToSequence(undo.Action{
-		Action:            "DOPODIUM",
-		Player:            activePlayer,
-		PreviousGameState: previousState,
-		PreviousMessage:   previousMessage,
-		GameID:            base.UID,
-	})
-	for i := range base.Player {
-		var contained = false
-		// When player UID is not in base.Podium
-		podium := *base.Podium.GetPodium()
-		for j := range podium {
-			if base.Player[i].UID == podium[j].Player.UID {
-				contained = true
-			}
+        // Otherwise exactly 2 left
+        base.Podium.AddPlayerToPodium(activePlayer)
+        sequence.AddActionToSequence(undo.Action{
+                Action:            "DOPODIUM",
+                Player:            activePlayer,
+                PreviousGameState: previousState,
+                PreviousMessage:   previousMessage,
+                GameID:            base.UID,
+        })
+        for i := range base.Player {
+                var contained = false
+                // When player UID is not in base.Podium
+                podium := *base.Podium.GetPodium()
+                for j := range podium {
+                        if base.Player[i].UID == podium[j].Player.UID {
+                                contained = true
+                        }
 
-		}
+                }
 
-		if !contained {
-			base.Podium.AddPlayerToPodium(&base.Player[i])
-			sequence.AddActionToSequence(undo.Action{
-				Action:            "DOPODIUM",
-				Player:            activePlayer,
-				PreviousGameState: previousState,
-				PreviousMessage:   previousMessage,
-				GameID:            base.UID,
-			})
+                if !contained {
+                        base.Podium.AddPlayerToPodium(&base.Player[i])
+                        sequence.AddActionToSequence(undo.Action{
+                                Action:            "DOPODIUM",
+                                Player:            activePlayer,
+                                PreviousGameState: previousState,
+                                PreviousMessage:   previousMessage,
+                                GameID:            base.UID,
+                        })
 
-			doWin(base)
-			throwRound := &activePlayer.ThrowRounds[base.ThrowRound-1]
-			throwRound.Done = true
-			activePlayer.Score.Score = 0
-			activePlayer.Score.ParkScore = 0
+                        doWin(base)
+                        throwRound := &activePlayer.ThrowRounds[base.ThrowRound-1]
+                        throwRound.Done = true
+                        activePlayer.Score.Score = 0
+                        activePlayer.Score.ParkScore = 0
 
-			previousScore := activePlayer.Score.Score
-			previousParkScore := activePlayer.Score.ParkScore
-			sequence.AddActionToSequence(undo.Action{
-				Action:            "DOWIN",
-				GameID:            base.UID,
-				PreviousGameState: previousState,
-				PreviousMessage:   previousMessage,
-				Player:            activePlayer,
-				PreviousScore:     previousScore,
-				PreviousParkScore: previousParkScore,
-			})
+                        previousScore := activePlayer.Score.Score
+                        previousParkScore := activePlayer.Score.ParkScore
+                        sequence.AddActionToSequence(undo.Action{
+                                Action:            "DOWIN",
+                                GameID:            base.UID,
+                                PreviousGameState: previousState,
+                                PreviousMessage:   previousMessage,
+                                Player:            activePlayer,
+                                PreviousScore:     previousScore,
+                                PreviousParkScore: previousParkScore,
+                        })
 
-			return
-		}
-	}
+                        return
+                }
+        }
 }
 
 // This will set game state for win case
 func doWin(base *BaseGame) {
-	// Set game state
-	base.GameState = "WON"
-	base.Message = "Game shot!"
-	base.SoundToPlay = "win"
+        // Set game state
+        base.GameState = "WON"
+        base.Message = "Game shot!"
+        base.SoundToPlay = "win"
+        base.EndTime = time.Now()  // Set end time when game is won
 }
 
 // This will strip response for Display function for FrontEnd
 // To minimize traffic size
 func stripDisplay(base *BaseGame) BaseGame {
-	var returnBase BaseGame
-	var returnPlayer = make([]player.Player, 0)
-	returnBase = *base
+        var returnBase BaseGame
+        var returnPlayer = make([]player.Player, 0)
+        returnBase = *base
 
-	for _, p := range returnBase.Player {
-		var tr = make([]throw.Round, 0)
-		p.ThrowRounds = tr
-		returnPlayer = append(returnPlayer, p)
-	}
+        for _, p := range returnBase.Player {
+                var tr = make([]throw.Round, 0)
+                p.ThrowRounds = tr
+                returnPlayer = append(returnPlayer, p)
+        }
 
-	returnBase.UndoLog = nil
-	returnBase.Player = returnPlayer
+        returnBase.UndoLog = nil
+        returnBase.Player = returnPlayer
 
-	return returnBase
+        return returnBase
 }
 
 // This will fill the players current throw round with 0s
 // for the case someone pressed nextPlayer before
 // entering all 3 throws
 func fillWithZeros(base *BaseGame, sequence *undo.Sequence, previousState, PreviousMessage string) {
-	// fill empty throws of active player with 0
-	// before switching to next player
-	activePlayer := &base.Player[base.ActivePlayer]
-	// Check if ongoing round
-	checkOngoingElseCreate(activePlayer, base, sequence)
+        // fill empty throws of active player with 0
+        // before switching to next player
+        activePlayer := &base.Player[base.ActivePlayer]
+        // Check if ongoing round
+        checkOngoingElseCreate(activePlayer, base, sequence)
 
-	currentThrowRound := &activePlayer.ThrowRounds[base.ThrowRound-1]
-	count := 3 - len(currentThrowRound.Throws)
-	if count != 0 {
-		for i := 0; i < count; i++ {
-			newThrow := &throw.Throw{
-				Number:   0,
-				Modifier: 1,
-			}
-			currentThrowRound.Throws = append(currentThrowRound.Throws, *newThrow)
-			sequence.AddActionToSequence(undo.Action{
-				Action:      "CREATETHROW",
-				Player:      activePlayer,
-				RoundNumber: currentThrowRound.Round,
-			})
+        currentThrowRound := &activePlayer.ThrowRounds[base.ThrowRound-1]
+        count := 3 - len(currentThrowRound.Throws)
+        if count != 0 {
+                for i := 0; i < count; i++ {
+                        newThrow := &throw.Throw{
+                                Number:   0,
+                                Modifier: 1,
+                        }
+                        currentThrowRound.Throws = append(currentThrowRound.Throws, *newThrow)
+                        sequence.AddActionToSequence(undo.Action{
+                                Action:      "CREATETHROW",
+                                Player:      activePlayer,
+                                RoundNumber: currentThrowRound.Round,
+                        })
 
-		}
-		currentThrowRound.Done = true
+                }
+                currentThrowRound.Done = true
 
-		// When X01 we need to set new parkScore
-		if base.Game == "x01" {
-			activePlayer.Score.ParkScore = activePlayer.Score.Score
-			previousParkScore := activePlayer.Score.ParkScore
-			previousScore := activePlayer.Score.Score
-			previousAverage := activePlayer.Average
-			previousThrowSum := activePlayer.ThrowSum
-			previousLastThree := activePlayer.LastThrows
+                // When X01 we need to set new parkScore
+                if base.Game == "x01" {
+                        activePlayer.Score.ParkScore = activePlayer.Score.Score
+                        previousParkScore := activePlayer.Score.ParkScore
+                        previousScore := activePlayer.Score.Score
+                        previousAverage := activePlayer.Average
+                        previousThrowSum := activePlayer.ThrowSum
+                        previousLastThree := activePlayer.LastThrows
 
-			sequence.AddActionToSequence(undo.Action{
-				Action:            "UPDATESCOREANDPARK",
-				Player:            activePlayer,
-				PreviousScore:     previousScore,
-				PreviousParkScore: previousParkScore,
-				PreviousAverage:   previousAverage,
-				PreviousThrowSum:  previousThrowSum,
-				PreviousLastThree: previousLastThree,
-			})
-		}
+                        sequence.AddActionToSequence(undo.Action{
+                                Action:            "UPDATESCOREANDPARK",
+                                Player:            activePlayer,
+                                PreviousScore:     previousScore,
+                                PreviousParkScore: previousParkScore,
+                                PreviousAverage:   previousAverage,
+                                PreviousThrowSum:  previousThrowSum,
+                                PreviousLastThree: previousLastThree,
+                        })
+                }
 
-		sequence.AddActionToSequence(undo.Action{
-			Action:            "CLOSEPLAYERTHROWROUND",
-			Player:            activePlayer,
-			RoundNumber:       currentThrowRound.Round,
-			GameID:            base.UID,
-			PreviousGameState: previousState,
-			PreviousMessage:   PreviousMessage,
-		})
-	}
+                sequence.AddActionToSequence(undo.Action{
+                        Action:            "CLOSEPLAYERTHROWROUND",
+                        Player:            activePlayer,
+                        RoundNumber:       currentThrowRound.Round,
+                        GameID:            base.UID,
+                        PreviousGameState: previousState,
+                        PreviousMessage:   PreviousMessage,
+                })
+        }
 
 }
 
 // This will switch to next player
 func switchToNextPlayer(base *BaseGame, h *ws.Hub) {
-	sequence := base.UndoLog.CreateSequence()
-	previousPlayerIndex := base.ActivePlayer
-	previousState := base.GameState
-	previousMessage := base.Message
+        sequence := base.UndoLog.CreateSequence()
+        previousPlayerIndex := base.ActivePlayer
+        previousState := base.GameState
+        previousMessage := base.Message
 
-	// Switch to next player
-	if base.GameState != "WON" {
-		activePlayer := &base.Player[base.ActivePlayer]
-		fillWithZeros(base, sequence, previousState, previousMessage)
+        // Switch to next player
+        if base.GameState != "WON" {
+                activePlayer := &base.Player[base.ActivePlayer]
+                fillWithZeros(base, sequence, previousState, previousMessage)
 
-		// Switch player
-		base.ActivePlayer = utils.ChooseNextPlayer(base.Player, base.ActivePlayer, base.Podium.GetPodium())
-		// Reset gamestate
-		base.GameState = "THROW"
-		base.Message = "-"
-		base.SoundToPlay = "nextplayer"
+                // Switch player
+                base.ActivePlayer = utils.ChooseNextPlayer(base.Player, base.ActivePlayer, base.Podium.GetPodium())
+                // Reset gamestate
+                base.GameState = "THROW"
+                base.Message = "-"
+                base.SoundToPlay = "nextplayer"
 
-		sequence.AddActionToSequence(undo.Action{
-			Action:              "NEXTPLAYER",
-			PreviousPlayerIndex: previousPlayerIndex,
-			GameID:              base.UID,
-		})
+                sequence.AddActionToSequence(undo.Action{
+                        Action:              "NEXTPLAYER",
+                        PreviousPlayerIndex: previousPlayerIndex,
+                        GameID:              base.UID,
+                })
 
-		// Set assets for Frontend
-		setFrontendAssets(activePlayer, base)
+                // Set assets for Frontend
+                setFrontendAssets(activePlayer, base)
 
-		// Update scoreboard
-		utils.WSSendUpdate(base.UID, h)
+                // Update scoreboard
+                utils.WSSendUpdate(base.UID, h)
 
-		// Check if throw round done by all players and increase
-		checkRoundDone(base, sequence)
-	}
+                // Check if throw round done by all players and increase
+                checkRoundDone(base, sequence)
+        }
 }
 
 // This will check if the round is done and increase overall
 // Throw round
 func checkRoundDone(base *BaseGame, sequence *undo.Sequence) {
-	// Check if to increase game.ThrowRound
-	if roundDone := utils.CheckRoundDone(base.Player, base.ThrowRound, base.Podium.GetPodium()); roundDone {
-		base.ThrowRound++
-		sequence.AddActionToSequence(undo.Action{
-			Action: "INCREASETHROWROUND",
-			GameID: base.UID,
-		})
-	}
+        // Check if to increase game.ThrowRound
+        if roundDone := utils.CheckRoundDone(base.Player, base.ThrowRound, base.Podium.GetPodium()); roundDone {
+                base.ThrowRound++
+                sequence.AddActionToSequence(undo.Action{
+                        Action: "INCREASETHROWROUND",
+                        GameID: base.UID,
+                })
+        }
 }
 
 // This will trigger undo
 func triggerUndo(base *BaseGame, h *ws.Hub) error {
-	// Check length and do not remove "CREATEGAME"
-	if len(*base.UndoLog) > 1 {
-		sequence, err := base.UndoLog.GetLastSequence()
-		if err != nil {
-			return err
-		}
+        // Check length and do not remove "CREATEGAME"
+        if len(*base.UndoLog) > 1 {
+                sequence, err := base.UndoLog.GetLastSequence()
+                if err != nil {
+                        return err
+                }
 
-		for _, a := range sequence.Action {
-			if a.Action == "CREATETHROWROUND" {
-				// look if there is CREATETHROWROUND in sequence
-				// if so resort and put it last as otherwise
-				// undo will be rendered unusable
+                for _, a := range sequence.Action {
+                        if a.Action == "CREATETHROWROUND" {
+                                // look if there is CREATETHROWROUND in sequence
+                                // if so resort and put it last as otherwise
+                                // undo will be rendered unusable
 
-				// park CREATETHROWROUND
-				parkAction := sequence.Action[0]
+                                // park CREATETHROWROUND
+                                parkAction := sequence.Action[0]
 
-				// remove CREATETHROWROUND from sequence
-				sequence.Action = sequence.Action[1:]
+                                // remove CREATETHROWROUND from sequence
+                                sequence.Action = sequence.Action[1:]
 
-				// add CREATETHROWROUND at the end
-				sequence.Action = append(sequence.Action, parkAction)
+                                // add CREATETHROWROUND at the end
+                                sequence.Action = append(sequence.Action, parkAction)
 
-				break
-			}
-		}
+                                break
+                        }
+                }
 
-		for _, a := range sequence.Action {
-			switch a.Action {
-			case "CREATETHROWROUND":
-				UndoCreateThrowRound(a)
-			case "CREATETHROW":
-				UndoCreateThrow(a)
-			case "DOWIN":
-				UndoWin(a, base)
-			case "DOPODIUM":
-				UndoDoPodium(a, base)
-			case "NEXTPLAYER":
-				UndoNextPlayer(a, base)
-			case "CLOSEPLAYERTHROWROUND":
-				UndoClosePlayerThrowRound(a, base)
-			case "INCREASETHROWROUND":
-				UndoIncreaseThrowRound(a, base)
-			// X01
-			case "UPDATESCORE":
-				UndoScore(a)
-			case "UPDATESCOREANDPARK":
-				UndoScoreAndPark(a)
-			case "X01BUST":
-				UndoBustAndWin(a, base)
-			// Cricket
-			case "REVEALNUMBER":
-				UndoRevealNumber(a, base)
-			case "INCREASEHITCOUNT":
-				UndoIncreaseHitCount(a)
-			case "CLOSEPLAYERNUMBER":
-				UndoClosePlayerNumber(a)
-			case "CLOSECONTROLLERNUMBER":
-				UndoCloseControllerNumber(a, base)
-			case "GAINPOINTS":
-				UndoGainPoints(a)
-			// ATC
-			case "ATCINCREASENUMBER":
-				UndoATCIncreaseNumber(a)
-			// Split
-			case "UPDATESPLITSCORE":
-				UndoUpdateSplitScore(a)
-			default:
-				break
-			}
-		}
+                for _, a := range sequence.Action {
+                        switch a.Action {
+                        case "CREATETHROWROUND":
+                                UndoCreateThrowRound(a)
+                        case "CREATETHROW":
+                                UndoCreateThrow(a)
+                        case "DOWIN":
+                                UndoWin(a, base)
+                        case "DOPODIUM":
+                                UndoDoPodium(a, base)
+                        case "NEXTPLAYER":
+                                UndoNextPlayer(a, base)
+                        case "CLOSEPLAYERTHROWROUND":
+                                UndoClosePlayerThrowRound(a, base)
+                        case "INCREASETHROWROUND":
+                                UndoIncreaseThrowRound(a, base)
+                        // X01
+                        case "UPDATESCORE":
+                                UndoScore(a)
+                        case "UPDATESCOREANDPARK":
+                                UndoScoreAndPark(a)
+                        case "X01BUST":
+                                UndoBustAndWin(a, base)
+                        // Cricket
+                        case "REVEALNUMBER":
+                                UndoRevealNumber(a, base)
+                        case "INCREASEHITCOUNT":
+                                UndoIncreaseHitCount(a)
+                        case "CLOSEPLAYERNUMBER":
+                                UndoClosePlayerNumber(a)
+                        case "CLOSECONTROLLERNUMBER":
+                                UndoCloseControllerNumber(a, base)
+                        case "GAINPOINTS":
+                                UndoGainPoints(a)
+                        // ATC
+                        case "ATCINCREASENUMBER":
+                                UndoATCIncreaseNumber(a)
+                        // Split
+                        case "UPDATESPLITSCORE":
+                                UndoUpdateSplitScore(a)
+                        default:
+                                break
+                        }
+                }
 
-		// Remove sequence from undo log
-		base.UndoLog.RemoveLastSequence()
+                // Remove sequence from undo log
+                base.UndoLog.RemoveLastSequence()
 
-		// reset assets
-		setFrontendAssets(&base.Player[base.ActivePlayer], base)
+                // reset assets
+                setFrontendAssets(&base.Player[base.ActivePlayer], base)
 
-		// Update trigger via hub
-		message := ws.Message{
-			Room: base.UID,
-			Data: []byte("update"),
-		}
+                // Update trigger via hub
+                message := ws.Message{
+                        Room: base.UID,
+                        Data: []byte("update"),
+                }
 
-		h.Broadcast <- message
-	}
+                h.Broadcast <- message
+        }
 
-	return nil
+        return nil
 }

--- a/game/cricket.go
+++ b/game/cricket.go
@@ -78,13 +78,18 @@ func (g *CricketGame) StartGame() error {
 		Action: "CREATEGAME",
 	})
 	g.Base.SoundToPlay = "nextplayer"
+        g.Base.EndTime = time.Time{}  // Reset to zero time
+        g.Base.EndTime = time.Time{}  // Set to zero time
 
 	return nil
 }
 
 // GetStatus will satisfy interface Game for game Cricket
 func (g *CricketGame) GetStatus() BaseGame {
-	return g.Base
+	if g.Base.EndTime.IsZero() return g.Basereturn g.Base g.Base.GameState == "WON" {
+		g.Base.EndTime = time.Now()
+}
+return g.Base
 }
 
 // GetStatusDisplay will satisfy interface Game for game Cricket
@@ -278,6 +283,8 @@ func (g *CricketGame) Rematch(h *ws.Hub) error {
 	g.Base.ActivePlayer = rg.Intn(len(g.Base.Player))
 	g.Base.ThrowRound = 1
 	g.Base.SoundToPlay = "nextplayer"
+        g.Base.EndTime = time.Time{}  // Reset to zero time
+        g.Base.EndTime = time.Time{}  // Set to zero time
 
 	// CreateScore for each player
 	// and init empty throw splice

--- a/game/cricket.go
+++ b/game/cricket.go
@@ -86,6 +86,10 @@ func (g *CricketGame) StartGame() error {
 
 // GetStatus will satisfy interface Game for game Cricket
 func (g *CricketGame) GetStatus() BaseGame {
+        if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
+                g.Base.EndTime = time.Now()
+        }
+
 	if g.Base.EndTime.IsZero() return g.Basereturn g.Base g.Base.GameState == "WON" {
 		g.Base.EndTime = time.Now()
 }

--- a/game/cricket.go
+++ b/game/cricket.go
@@ -78,32 +78,18 @@ func (g *CricketGame) StartGame() error {
 		Action: "CREATEGAME",
 	})
 	g.Base.SoundToPlay = "nextplayer"
-        g.Base.EndTime = time.Time{}  // Reset to zero time
-        g.Base.EndTime = time.Time{}  // Set to zero time
+	g.Base.EndTime = time.Time{} // Reset to zero time
+	g.Base.EndTime = time.Time{} // Set to zero time
 
 	return nil
 }
 
 // GetStatus will satisfy interface Game for game Cricket
 func (g *CricketGame) GetStatus() BaseGame {
-        if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
-                g.Base.EndTime = time.Now()
-        }
-        return g.Base
-
-        if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
-                g.Base.EndTime = time.Now()
-        }
-        return g.Base
-
-        if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
-                g.Base.EndTime = time.Now()
-        }
-
-	if g.Base.EndTime.IsZero() return g.Basereturn g.Base g.Base.GameState == "WON" {
+	if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
 		g.Base.EndTime = time.Now()
-}
-return g.Base
+	}
+	return g.Base
 }
 
 // GetStatusDisplay will satisfy interface Game for game Cricket
@@ -297,8 +283,8 @@ func (g *CricketGame) Rematch(h *ws.Hub) error {
 	g.Base.ActivePlayer = rg.Intn(len(g.Base.Player))
 	g.Base.ThrowRound = 1
 	g.Base.SoundToPlay = "nextplayer"
-        g.Base.EndTime = time.Time{}  // Reset to zero time
-        g.Base.EndTime = time.Time{}  // Set to zero time
+	g.Base.EndTime = time.Time{} // Reset to zero time
+	g.Base.EndTime = time.Time{} // Set to zero time
 
 	// CreateScore for each player
 	// and init empty throw splice

--- a/game/cricket.go
+++ b/game/cricket.go
@@ -94,6 +94,11 @@ func (g *CricketGame) GetStatus() BaseGame {
         if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
                 g.Base.EndTime = time.Now()
         }
+        return g.Base
+
+        if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
+                g.Base.EndTime = time.Now()
+        }
 
 	if g.Base.EndTime.IsZero() return g.Basereturn g.Base g.Base.GameState == "WON" {
 		g.Base.EndTime = time.Now()

--- a/game/cricket.go
+++ b/game/cricket.go
@@ -89,6 +89,11 @@ func (g *CricketGame) GetStatus() BaseGame {
         if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
                 g.Base.EndTime = time.Now()
         }
+        return g.Base
+
+        if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
+                g.Base.EndTime = time.Now()
+        }
 
 	if g.Base.EndTime.IsZero() return g.Basereturn g.Base g.Base.GameState == "WON" {
 		g.Base.EndTime = time.Now()

--- a/game/elimination.go
+++ b/game/elimination.go
@@ -60,6 +60,11 @@ func (g *EliminationGame) GetStatus() BaseGame {
         if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
                 g.Base.EndTime = time.Now()
         }
+        return g.Base
+
+        if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
+                g.Base.EndTime = time.Now()
+        }
 
 	if g.Base.EndTime.IsZero() return g.Basereturn g.Base g.Base.GameState == "WON" {
 		g.Base.EndTime = time.Now()

--- a/game/elimination.go
+++ b/game/elimination.go
@@ -16,13 +16,13 @@ import (
 	"github.com/Kleinish/dascr-board/ws"
 )
 
-// EliminiationGame will hold the Eliminiation game information
-type EliminiationGame struct {
+// EliminationGame will hold the Elimination game information
+type EliminationGame struct {
 	Base BaseGame
 }
 
-// StartGame will satisfy interface Game for game Eliminiation
-func (g *EliminiationGame) StartGame() error {
+// StartGame will satisfy interface Game for game Elimination
+func (g *EliminationGame) StartGame() error {
 	// Score to int
 	setupscore := 0
 
@@ -49,46 +49,32 @@ func (g *EliminiationGame) StartGame() error {
 		Action: "CREATEGAME",
 	})
 	g.Base.SoundToPlay = "nextplayer"
-        g.Base.EndTime = time.Time{}  // Reset to zero time
-        g.Base.EndTime = time.Time{}  // Set to zero time
+	g.Base.EndTime = time.Time{} // Reset to zero time
+	g.Base.EndTime = time.Time{} // Set to zero time
 
 	return nil
 }
 
-// GetStatus will satisfy interface Game for game Eliminiation
+// GetStatus will satisfy interface Game for game Elimination
 func (g *EliminationGame) GetStatus() BaseGame {
-        if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
-                g.Base.EndTime = time.Now()
-        }
-        return g.Base
-
-        if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
-                g.Base.EndTime = time.Now()
-        }
-        return g.Base
-
-        if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
-                g.Base.EndTime = time.Now()
-        }
-
-	if g.Base.EndTime.IsZero() return g.Basereturn g.Base g.Base.GameState == "WON" {
+	if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
 		g.Base.EndTime = time.Now()
-}
-return g.Base
+	}
+	return g.Base
 }
 
-// GetStatusDisplay will satisfy interface Game for game Eliminiation
-func (g *EliminiationGame) GetStatusDisplay() BaseGame {
+// GetStatusDisplay will satisfy interface Game for game Elimination
+func (g *EliminationGame) GetStatusDisplay() BaseGame {
 	return stripDisplay(&g.Base)
 }
 
-// NextPlayer will satisfy interface Game for game Eliminiation
-func (g *EliminiationGame) NextPlayer(h *ws.Hub) {
+// NextPlayer will satisfy interface Game for game Elimination
+func (g *EliminationGame) NextPlayer(h *ws.Hub) {
 	switchToNextPlayer(&g.Base, h)
 }
 
-// RequestThrow will satisfy interface Game for game Eliminiation
-func (g *EliminiationGame) RequestThrow(number, modifier int, h *ws.Hub) error {
+// RequestThrow will satisfy interface Game for game Elimination
+func (g *EliminationGame) RequestThrow(number, modifier int, h *ws.Hub) error {
 	sequence := g.Base.UndoLog.CreateSequence()
 
 	// Targetnumber to int
@@ -142,8 +128,8 @@ func (g *EliminiationGame) RequestThrow(number, modifier int, h *ws.Hub) error {
 	return fmt.Errorf("game state is '%+v', so no throw accepted", g.Base.GameState)
 }
 
-// Undo will satisfy interface Game for game Eliminiation
-func (g *EliminiationGame) Undo(h *ws.Hub) error {
+// Undo will satisfy interface Game for game Elimination
+func (g *EliminationGame) Undo(h *ws.Hub) error {
 	if err := triggerUndo(&g.Base, h); err != nil {
 		return err
 	}
@@ -151,8 +137,8 @@ func (g *EliminiationGame) Undo(h *ws.Hub) error {
 	return nil
 }
 
-// Rematch will satisfy interface Game for game Eliminiation
-func (g *EliminiationGame) Rematch(h *ws.Hub) error {
+// Rematch will satisfy interface Game for game Elimination
+func (g *EliminationGame) Rematch(h *ws.Hub) error {
 	// Score to int
 	setupscore := 0
 
@@ -168,8 +154,8 @@ func (g *EliminiationGame) Rematch(h *ws.Hub) error {
 	g.Base.ActivePlayer = rg.Intn(len(g.Base.Player))
 	g.Base.ThrowRound = 1
 	g.Base.SoundToPlay = "nextplayer"
-        g.Base.EndTime = time.Time{}  // Reset to zero time
-        g.Base.EndTime = time.Time{}  // Set to zero time
+	g.Base.EndTime = time.Time{} // Reset to zero time
+	g.Base.EndTime = time.Time{} // Set to zero time
 
 	// CreateScore for each player
 	// and init empty throw splice
@@ -199,7 +185,7 @@ func (g *EliminiationGame) Rematch(h *ws.Hub) error {
 }
 
 // This will handle x01bust and reset game state
-func eliminationbust(nextState string, game *EliminiationGame, throwRound *throw.Round, activePlayer *player.Player, sequence *undo.Sequence, previousScore int) {
+func eliminationbust(nextState string, game *EliminationGame, throwRound *throw.Round, activePlayer *player.Player, sequence *undo.Sequence, previousScore int) {
 	oldState := game.Base.GameState
 	previousMessage := game.Base.Message
 	previousParkScore := activePlayer.Score.ParkScore
@@ -229,7 +215,7 @@ func eliminationbust(nextState string, game *EliminiationGame, throwRound *throw
 }
 
 // This will handle x01win
-func eliminationwin(game *EliminiationGame, modifier int, throwRound *throw.Round, activePlayer *player.Player, sequence *undo.Sequence) {
+func eliminationwin(game *EliminationGame, modifier int, throwRound *throw.Round, activePlayer *player.Player, sequence *undo.Sequence) {
 	previousMessage := game.Base.Message
 	previousState := game.Base.GameState
 	previousScore := activePlayer.Score.Score
@@ -262,7 +248,7 @@ func eliminationwin(game *EliminiationGame, modifier int, throwRound *throw.Roun
 }
 
 // This will handle the normal throw routine
-func eliminationThrow(game *EliminiationGame, newScore, number, modifier int, throwRound *throw.Round, activePlayer *player.Player, sequence *undo.Sequence) {
+func eliminationThrow(game *EliminationGame, newScore, number, modifier int, throwRound *throw.Round, activePlayer *player.Player, sequence *undo.Sequence) {
 	// Reset sound
 	game.Base.SoundToPlay = "none"
 	// First of all elimination check
@@ -354,7 +340,7 @@ func eliminationThrow(game *EliminiationGame, newScore, number, modifier int, th
 }
 
 // This will check if a checkout is even possible anymore and return a bool
-func eliminationCheckoutPossible(game *EliminiationGame, newScore int) bool {
+func eliminationCheckoutPossible(game *EliminationGame, newScore int) bool {
 	// targetnumber to int
 	target, err := strconv.Atoi(game.Base.Variant)
 	if err != nil {
@@ -368,7 +354,7 @@ func eliminationCheckoutPossible(game *EliminiationGame, newScore int) bool {
 }
 
 // This will check if the checkout condition is met and return bool
-func eliminationCheckoutMet(game *EliminiationGame, modifier int) bool {
+func eliminationCheckoutMet(game *EliminationGame, modifier int) bool {
 	if game.Base.Out == "double" {
 		return modifier == 2
 	} else if game.Base.Out == "master" {
@@ -378,7 +364,7 @@ func eliminationCheckoutMet(game *EliminiationGame, modifier int) bool {
 }
 
 // This will check if a checkin is possible and return a bool
-func eliminationCheckinPossible(game *EliminiationGame, modifier int) bool {
+func eliminationCheckinPossible(game *EliminationGame, modifier int) bool {
 	if game.Base.In == "double" {
 		return modifier == 2
 	} else if game.Base.In == "master" {
@@ -388,7 +374,7 @@ func eliminationCheckinPossible(game *EliminiationGame, modifier int) bool {
 }
 
 // This will check players for same score and reset if applicable
-func eliminate(game *EliminiationGame, newScore int, activePlayer *player.Player, sequence *undo.Sequence) {
+func eliminate(game *EliminationGame, newScore int, activePlayer *player.Player, sequence *undo.Sequence) {
 	for i := range game.Base.Player {
 		pl := &game.Base.Player[i]
 		if pl.UID != activePlayer.UID && pl.Score.Score == newScore {

--- a/game/elimination.go
+++ b/game/elimination.go
@@ -56,7 +56,11 @@ func (g *EliminiationGame) StartGame() error {
 }
 
 // GetStatus will satisfy interface Game for game Eliminiation
-func (g *EliminiationGame) GetStatus() BaseGame {
+func (g *EliminationGame) GetStatus() BaseGame {
+        if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
+                g.Base.EndTime = time.Now()
+        }
+
 	if g.Base.EndTime.IsZero() return g.Basereturn g.Base g.Base.GameState == "WON" {
 		g.Base.EndTime = time.Now()
 }

--- a/game/elimination.go
+++ b/game/elimination.go
@@ -65,6 +65,11 @@ func (g *EliminationGame) GetStatus() BaseGame {
         if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
                 g.Base.EndTime = time.Now()
         }
+        return g.Base
+
+        if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
+                g.Base.EndTime = time.Now()
+        }
 
 	if g.Base.EndTime.IsZero() return g.Basereturn g.Base g.Base.GameState == "WON" {
 		g.Base.EndTime = time.Now()

--- a/game/elimination.go
+++ b/game/elimination.go
@@ -49,13 +49,18 @@ func (g *EliminiationGame) StartGame() error {
 		Action: "CREATEGAME",
 	})
 	g.Base.SoundToPlay = "nextplayer"
+        g.Base.EndTime = time.Time{}  // Reset to zero time
+        g.Base.EndTime = time.Time{}  // Set to zero time
 
 	return nil
 }
 
 // GetStatus will satisfy interface Game for game Eliminiation
 func (g *EliminiationGame) GetStatus() BaseGame {
-	return g.Base
+	if g.Base.EndTime.IsZero() return g.Basereturn g.Base g.Base.GameState == "WON" {
+		g.Base.EndTime = time.Now()
+}
+return g.Base
 }
 
 // GetStatusDisplay will satisfy interface Game for game Eliminiation
@@ -149,6 +154,8 @@ func (g *EliminiationGame) Rematch(h *ws.Hub) error {
 	g.Base.ActivePlayer = rg.Intn(len(g.Base.Player))
 	g.Base.ThrowRound = 1
 	g.Base.SoundToPlay = "nextplayer"
+        g.Base.EndTime = time.Time{}  // Reset to zero time
+        g.Base.EndTime = time.Time{}  // Set to zero time
 
 	// CreateScore for each player
 	// and init empty throw splice

--- a/game/engine.go
+++ b/game/engine.go
@@ -219,7 +219,7 @@ func CreateGame(db *sql.DB, h *ws.Hub) http.HandlerFunc {
 			}
 
 		case "elim":
-			data.GameObject = &EliminiationGame{
+			data.GameObject = &EliminationGame{
 				Base: BaseGame{
 					UID:          data.UID,
 					Game:         data.Game,

--- a/game/interface.go
+++ b/game/interface.go
@@ -1,40 +1,43 @@
 package game
 
 import (
-	"github.com/Kleinish/dascr-board/player"
-	"github.com/Kleinish/dascr-board/podium"
-	"github.com/Kleinish/dascr-board/settings"
-	"github.com/Kleinish/dascr-board/undo"
-	"github.com/Kleinish/dascr-board/ws"
+        "time"
+
+        "github.com/Kleinish/dascr-board/player"
+        "github.com/Kleinish/dascr-board/podium"
+        "github.com/Kleinish/dascr-board/settings"
+        "github.com/Kleinish/dascr-board/undo"
+        "github.com/Kleinish/dascr-board/ws"
 )
 
 // BaseGame will hold all the game specific stuff
 // for all games combined
 type BaseGame struct {
-	UID               string
-	Game              string
-	Player            []player.Player
-	Variant           string
-	In                string
-	Out               string
-	ActivePlayer      int
-	ThrowRound        int
-	GameState         string
-	Message           string
-	Settings          *settings.Settings
-	UndoLog           *undo.Log
-	Podium            *podium.Podium
-	CricketController *CricketGameController
-	SoundToPlay       string
+        UID               string
+        Game              string
+        Player            []player.Player
+        Variant           string
+        In                string
+        Out               string
+        ActivePlayer      int
+        ThrowRound        int
+        GameState         string
+        Message           string
+        Settings          *settings.Settings
+        UndoLog           *undo.Log
+        Podium            *podium.Podium
+        CricketController *CricketGameController
+        SoundToPlay       string
+        EndTime           time.Time `json:"endTime"`
 }
 
 // Game will be the interface for different games
 type Game interface {
-	StartGame() error
-	GetStatus() BaseGame
-	GetStatusDisplay() BaseGame
-	NextPlayer(h *ws.Hub)
-	RequestThrow(number, modifier int, h *ws.Hub) error
-	Undo(h *ws.Hub) error
-	Rematch(h *ws.Hub) error
+        StartGame() error
+        GetStatus() BaseGame
+        GetStatusDisplay() BaseGame
+        NextPlayer(h *ws.Hub)
+        RequestThrow(number, modifier int, h *ws.Hub) error
+        Undo(h *ws.Hub) error
+        Rematch(h *ws.Hub) error
 }

--- a/game/shanghai.go
+++ b/game/shanghai.go
@@ -41,32 +41,17 @@ func (g *ShanghaiGame) StartGame() error {
 		Action: "CREATEGAME",
 	})
 	g.Base.SoundToPlay = "nextplayer"
-        g.Base.EndTime = time.Time{}  // Reset to zero time
-        g.Base.EndTime = time.Time{}  // Set to zero time
+	g.Base.EndTime = time.Time{} // Reset to zero time
 
 	return nil
 }
 
 // GetStatus will satisfy interface Game for Shanghai
 func (g *ShanghaiGame) GetStatus() BaseGame {
-        if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
-                g.Base.EndTime = time.Now()
-        }
-        return g.Base
-
-        if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
-                g.Base.EndTime = time.Now()
-        }
-        return g.Base
-
-        if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
-                g.Base.EndTime = time.Now()
-        }
-
-	if g.Base.EndTime.IsZero() return g.Basereturn g.Base g.Base.GameState == "WON" {
+	if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
 		g.Base.EndTime = time.Now()
-}
-return g.Base
+	}
+	return g.Base
 }
 
 // GetStatusDisplay will satisfy interface Game for game Shanghai
@@ -145,8 +130,7 @@ func (g *ShanghaiGame) Rematch(h *ws.Hub) error {
 	g.Base.ActivePlayer = rg.Intn(len(g.Base.Player))
 	g.Base.ThrowRound = 1
 	g.Base.SoundToPlay = "nextplayer"
-        g.Base.EndTime = time.Time{}  // Reset to zero time
-        g.Base.EndTime = time.Time{}  // Set to zero time
+	g.Base.EndTime = time.Time{} // Reset to zero time
 
 	for i := range g.Base.Player {
 		score := score.BaseScore{

--- a/game/shanghai.go
+++ b/game/shanghai.go
@@ -49,6 +49,10 @@ func (g *ShanghaiGame) StartGame() error {
 
 // GetStatus will satisfy interface Game for Shanghai
 func (g *ShanghaiGame) GetStatus() BaseGame {
+        if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
+                g.Base.EndTime = time.Now()
+        }
+
 	if g.Base.EndTime.IsZero() return g.Basereturn g.Base g.Base.GameState == "WON" {
 		g.Base.EndTime = time.Now()
 }

--- a/game/shanghai.go
+++ b/game/shanghai.go
@@ -57,6 +57,11 @@ func (g *ShanghaiGame) GetStatus() BaseGame {
         if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
                 g.Base.EndTime = time.Now()
         }
+        return g.Base
+
+        if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
+                g.Base.EndTime = time.Now()
+        }
 
 	if g.Base.EndTime.IsZero() return g.Basereturn g.Base g.Base.GameState == "WON" {
 		g.Base.EndTime = time.Now()

--- a/game/shanghai.go
+++ b/game/shanghai.go
@@ -52,6 +52,11 @@ func (g *ShanghaiGame) GetStatus() BaseGame {
         if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
                 g.Base.EndTime = time.Now()
         }
+        return g.Base
+
+        if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
+                g.Base.EndTime = time.Now()
+        }
 
 	if g.Base.EndTime.IsZero() return g.Basereturn g.Base g.Base.GameState == "WON" {
 		g.Base.EndTime = time.Now()

--- a/game/shanghai.go
+++ b/game/shanghai.go
@@ -41,13 +41,18 @@ func (g *ShanghaiGame) StartGame() error {
 		Action: "CREATEGAME",
 	})
 	g.Base.SoundToPlay = "nextplayer"
+        g.Base.EndTime = time.Time{}  // Reset to zero time
+        g.Base.EndTime = time.Time{}  // Set to zero time
 
 	return nil
 }
 
 // GetStatus will satisfy interface Game for Shanghai
 func (g *ShanghaiGame) GetStatus() BaseGame {
-	return g.Base
+	if g.Base.EndTime.IsZero() return g.Basereturn g.Base g.Base.GameState == "WON" {
+		g.Base.EndTime = time.Now()
+}
+return g.Base
 }
 
 // GetStatusDisplay will satisfy interface Game for game Shanghai
@@ -126,6 +131,8 @@ func (g *ShanghaiGame) Rematch(h *ws.Hub) error {
 	g.Base.ActivePlayer = rg.Intn(len(g.Base.Player))
 	g.Base.ThrowRound = 1
 	g.Base.SoundToPlay = "nextplayer"
+        g.Base.EndTime = time.Time{}  // Reset to zero time
+        g.Base.EndTime = time.Time{}  // Set to zero time
 
 	for i := range g.Base.Player {
 		score := score.BaseScore{

--- a/game/split.go
+++ b/game/split.go
@@ -49,13 +49,18 @@ func (g *SplitGame) StartGame() error {
 		Action: "CREATEGAME",
 	})
 	g.Base.SoundToPlay = "nextplayer"
+        g.Base.EndTime = time.Time{}  // Reset to zero time
+        g.Base.EndTime = time.Time{}  // Set to zero time
 
 	return nil
 }
 
 // GetStatus will satisfy interface Game for game Split
 func (g *SplitGame) GetStatus() BaseGame {
-	return g.Base
+	if g.Base.EndTime.IsZero() return g.Basereturn g.Base g.Base.GameState == "WON" {
+		g.Base.EndTime = time.Now()
+}
+return g.Base
 }
 
 // GetStatusDisplay will satisfy interface Game for game Split
@@ -141,6 +146,8 @@ func (g *SplitGame) Rematch(h *ws.Hub) error {
 	g.Base.ActivePlayer = rg.Intn(len(g.Base.Player))
 	g.Base.ThrowRound = 1
 	g.Base.SoundToPlay = "nextplayer"
+        g.Base.EndTime = time.Time{}  // Reset to zero time
+        g.Base.EndTime = time.Time{}  // Set to zero time
 
 	// Init start score vor edart
 	startscore := 40

--- a/game/split.go
+++ b/game/split.go
@@ -65,6 +65,11 @@ func (g *SplitGame) GetStatus() BaseGame {
         if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
                 g.Base.EndTime = time.Now()
         }
+        return g.Base
+
+        if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
+                g.Base.EndTime = time.Now()
+        }
 
 	if g.Base.EndTime.IsZero() return g.Basereturn g.Base g.Base.GameState == "WON" {
 		g.Base.EndTime = time.Now()

--- a/game/split.go
+++ b/game/split.go
@@ -60,6 +60,11 @@ func (g *SplitGame) GetStatus() BaseGame {
         if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
                 g.Base.EndTime = time.Now()
         }
+        return g.Base
+
+        if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
+                g.Base.EndTime = time.Now()
+        }
 
 	if g.Base.EndTime.IsZero() return g.Basereturn g.Base g.Base.GameState == "WON" {
 		g.Base.EndTime = time.Now()

--- a/game/split.go
+++ b/game/split.go
@@ -49,32 +49,18 @@ func (g *SplitGame) StartGame() error {
 		Action: "CREATEGAME",
 	})
 	g.Base.SoundToPlay = "nextplayer"
-        g.Base.EndTime = time.Time{}  // Reset to zero time
-        g.Base.EndTime = time.Time{}  // Set to zero time
+	g.Base.EndTime = time.Time{} // Reset to zero time
+	g.Base.EndTime = time.Time{} // Set to zero time
 
 	return nil
 }
 
 // GetStatus will satisfy interface Game for game Split
 func (g *SplitGame) GetStatus() BaseGame {
-        if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
-                g.Base.EndTime = time.Now()
-        }
-        return g.Base
-
-        if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
-                g.Base.EndTime = time.Now()
-        }
-        return g.Base
-
-        if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
-                g.Base.EndTime = time.Now()
-        }
-
-	if g.Base.EndTime.IsZero() return g.Basereturn g.Base g.Base.GameState == "WON" {
+	if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
 		g.Base.EndTime = time.Now()
-}
-return g.Base
+	}
+	return g.Base
 }
 
 // GetStatusDisplay will satisfy interface Game for game Split
@@ -160,8 +146,8 @@ func (g *SplitGame) Rematch(h *ws.Hub) error {
 	g.Base.ActivePlayer = rg.Intn(len(g.Base.Player))
 	g.Base.ThrowRound = 1
 	g.Base.SoundToPlay = "nextplayer"
-        g.Base.EndTime = time.Time{}  // Reset to zero time
-        g.Base.EndTime = time.Time{}  // Set to zero time
+	g.Base.EndTime = time.Time{} // Reset to zero time
+	g.Base.EndTime = time.Time{} // Set to zero time
 
 	// Init start score vor edart
 	startscore := 40

--- a/game/split.go
+++ b/game/split.go
@@ -57,6 +57,10 @@ func (g *SplitGame) StartGame() error {
 
 // GetStatus will satisfy interface Game for game Split
 func (g *SplitGame) GetStatus() BaseGame {
+        if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
+                g.Base.EndTime = time.Now()
+        }
+
 	if g.Base.EndTime.IsZero() return g.Basereturn g.Base g.Base.GameState == "WON" {
 		g.Base.EndTime = time.Now()
 }

--- a/game/x01.go
+++ b/game/x01.go
@@ -59,10 +59,10 @@ func (g *X01Game) StartGame() error {
 
 // GetStatus will satisfy interface Game for game X01
 func (g *X01Game) GetStatus() BaseGame {
-        if g.Base.EndTime.IsZero() return g.Basereturn g.Base g.Base.GameState == "WON" {
-		g.Base.EndTime = time.Now()
-}
-return g.Base
+        if g.Base.EndTime.IsZero() && g.Base.GameState == "WON" {
+                g.Base.EndTime = time.Now()
+        }
+        return g.Base
 }
 
 // GetStatusDisplay will satisfy interface Game for game X01

--- a/game/x01.go
+++ b/game/x01.go
@@ -1,353 +1,359 @@
 package game
 
 import (
-	"fmt"
-	"math/rand"
-	"strconv"
-	"time"
+        "fmt"
+        "math/rand"
+        "strconv"
+        "time"
 
-	"github.com/Kleinish/dascr-board/player"
-	"github.com/Kleinish/dascr-board/podium"
-	"github.com/Kleinish/dascr-board/score"
-	"github.com/Kleinish/dascr-board/throw"
-	"github.com/Kleinish/dascr-board/undo"
-	"github.com/Kleinish/dascr-board/utils"
-	"github.com/Kleinish/dascr-board/ws"
+        "github.com/Kleinish/dascr-board/player"
+        "github.com/Kleinish/dascr-board/podium"
+        "github.com/Kleinish/dascr-board/score"
+        "github.com/Kleinish/dascr-board/throw"
+        "github.com/Kleinish/dascr-board/undo"
+        "github.com/Kleinish/dascr-board/utils"
+        "github.com/Kleinish/dascr-board/ws"
 )
 
 // X01Game will hold the X01 game information
 type X01Game struct {
-	Base BaseGame
+        Base BaseGame
 }
 
 // StartGame will satisfy interface Game for game X01
 func (g *X01Game) StartGame() error {
-	// Score to int
-	setupscore, err := strconv.Atoi(g.Base.Variant)
-	if err != nil {
-		return err
-	}
+        // Score to int
+        setupscore, err := strconv.Atoi(g.Base.Variant)
+        if err != nil {
+                return err
+        }
 
-	// CreateScore for each player
-	// and init empty throw splice
-	for i := range g.Base.Player {
-		score := score.BaseScore{
-			Score:        setupscore,
-			ParkScore:    setupscore,
-			InitialScore: setupscore,
-		}
-		g.Base.Player[i].Score = score
-		g.Base.Player[i].ThrowRounds = make([]throw.Round, 0)
-		g.Base.Player[i].LastThrows = make([]throw.Throw, 3)
-		g.Base.Player[i].ThrowSum = 0
-		g.Base.Player[i].Average = 0
-	}
+        // CreateScore for each player
+        // and init empty throw splice
+        for i := range g.Base.Player {
+                score := score.BaseScore{
+                        Score:        setupscore,
+                        ParkScore:    setupscore,
+                        InitialScore: setupscore,
+                }
+                g.Base.Player[i].Score = score
+                g.Base.Player[i].ThrowRounds = make([]throw.Round, 0)
+                g.Base.Player[i].LastThrows = make([]throw.Throw, 3)
+                g.Base.Player[i].ThrowSum = 0
+                g.Base.Player[i].Average = 0
+        }
 
-	g.Base.Podium = &podium.Podium{}
+        g.Base.Podium = &podium.Podium{}
 
-	g.Base.UndoLog = &undo.Log{}
-	sequence := g.Base.UndoLog.CreateSequence()
-	sequence.AddActionToSequence(undo.Action{
-		Action: "CREATEGAME",
-	})
-	g.Base.SoundToPlay = "nextplayer"
+        g.Base.UndoLog = &undo.Log{}
+        sequence := g.Base.UndoLog.CreateSequence()
+        sequence.AddActionToSequence(undo.Action{
+                Action: "CREATEGAME",
+        })
+        g.Base.SoundToPlay = "nextplayer"
+        g.Base.EndTime = time.Time{}  // Reset to zero time
+        g.Base.EndTime = time.Time{}  // Set to zero time
 
-	return nil
+        return nil
 }
 
 // GetStatus will satisfy interface Game for game X01
 func (g *X01Game) GetStatus() BaseGame {
-	return g.Base
+        if g.Base.EndTime.IsZero() return g.Basereturn g.Base g.Base.GameState == "WON" {
+		g.Base.EndTime = time.Now()
+}
+return g.Base
 }
 
 // GetStatusDisplay will satisfy interface Game for game X01
 func (g *X01Game) GetStatusDisplay() BaseGame {
-	return stripDisplay(&g.Base)
+        return stripDisplay(&g.Base)
 }
 
 // NextPlayer will satisfy interface Game for game X01
 func (g *X01Game) NextPlayer(h *ws.Hub) {
-	switchToNextPlayer(&g.Base, h)
+        switchToNextPlayer(&g.Base, h)
 }
 
 // RequestThrow will satisfy interface Game for game X01
 func (g *X01Game) RequestThrow(number, modifier int, h *ws.Hub) error {
-	sequence := g.Base.UndoLog.CreateSequence()
+        sequence := g.Base.UndoLog.CreateSequence()
 
-	points := number * modifier
-	activePlayer := &g.Base.Player[g.Base.ActivePlayer]
-	// Check game state
-	if g.Base.GameState == "THROW" {
-		// check if ongoing round else create
-		checkOngoingElseCreate(activePlayer, &g.Base, sequence)
+        points := number * modifier
+        activePlayer := &g.Base.Player[g.Base.ActivePlayer]
+        // Check game state
+        if g.Base.GameState == "THROW" {
+                // check if ongoing round else create
+                checkOngoingElseCreate(activePlayer, &g.Base, sequence)
 
-		// Add Throw to last round
-		throwRound := addThrowToCurrentRound(activePlayer, &g.Base, sequence, number, modifier)
+                // Add Throw to last round
+                throwRound := addThrowToCurrentRound(activePlayer, &g.Base, sequence, number, modifier)
 
-		// New score will be
-		newScore := activePlayer.Score.Score - points
+                // New score will be
+                newScore := activePlayer.Score.Score - points
 
-		// Add 100 if punisher enabled
-		if g.Base.Settings.Punisher {
-			if number == 0 || modifier == 0 {
-				newScore = activePlayer.Score.Score + 100
-			}
-		}
+                // Add 100 if punisher enabled
+                if g.Base.Settings.Punisher {
+                        if number == 0 || modifier == 0 {
+                                newScore = activePlayer.Score.Score + 100
+                        }
+                }
 
-		// Handle cases win, bust, normal throw
-		switch {
-		// BUST
-		case newScore < 0:
-			x01bust("BUST", g, throwRound, activePlayer, sequence, activePlayer.Score.Score)
-		// WIN
-		case newScore == 0:
-			x01win(g, modifier, throwRound, activePlayer, sequence)
-		// NORMAL THROW
-		default:
-			normalThrow(g, newScore, number, modifier, throwRound, activePlayer, sequence)
-		}
+                // Handle cases win, bust, normal throw
+                switch {
+                // BUST
+                case newScore < 0:
+                        x01bust("BUST", g, throwRound, activePlayer, sequence, activePlayer.Score.Score)
+                // WIN
+                case newScore == 0:
+                        x01win(g, modifier, throwRound, activePlayer, sequence)
+                // NORMAL THROW
+                default:
+                        normalThrow(g, newScore, number, modifier, throwRound, activePlayer, sequence)
+                }
 
-		// Set assets for Frontend
-		setFrontendAssets(activePlayer, &g.Base)
+                // Set assets for Frontend
+                setFrontendAssets(activePlayer, &g.Base)
 
-		// Update scoreboard
-		utils.WSSendUpdate(g.Base.UID, h)
+                // Update scoreboard
+                utils.WSSendUpdate(g.Base.UID, h)
 
-		return nil
-	}
+                return nil
+        }
 
-	return fmt.Errorf("game state is '%+v', so no throw accepted", g.Base.GameState)
+        return fmt.Errorf("game state is '%+v', so no throw accepted", g.Base.GameState)
 }
 
 // Undo will satisfy interface Game for game X01
 func (g *X01Game) Undo(h *ws.Hub) error {
-	if err := triggerUndo(&g.Base, h); err != nil {
-		return err
-	}
+        if err := triggerUndo(&g.Base, h); err != nil {
+                return err
+        }
 
-	return nil
+        return nil
 }
 
 // Rematch will satisfy interface Game for game X01
 func (g *X01Game) Rematch(h *ws.Hub) error {
-	// Score to int
-	setupscore, err := strconv.Atoi(g.Base.Variant)
-	if err != nil {
-		return err
-	}
+        // Score to int
+        setupscore, err := strconv.Atoi(g.Base.Variant)
+        if err != nil {
+                return err
+        }
 
-	// Init random number generator
-	s := rand.NewSource(time.Now().Unix())
-	rg := rand.New(s)
+        // Init random number generator
+        s := rand.NewSource(time.Now().Unix())
+        rg := rand.New(s)
 
-	// Reset game state
-	g.Base.Message = ""
-	g.Base.GameState = "THROW"
-	g.Base.Podium.ResetPodium()
-	g.Base.UndoLog.ClearLog()
-	g.Base.ActivePlayer = rg.Intn(len(g.Base.Player))
-	g.Base.ThrowRound = 1
-	g.Base.SoundToPlay = "nextplayer"
+        // Reset game state
+        g.Base.Message = ""
+        g.Base.GameState = "THROW"
+        g.Base.Podium.ResetPodium()
+        g.Base.UndoLog.ClearLog()
+        g.Base.ActivePlayer = rg.Intn(len(g.Base.Player))
+        g.Base.ThrowRound = 1
+        g.Base.SoundToPlay = "nextplayer"
+        g.Base.EndTime = time.Time{}  // Reset to zero time
 
-	// CreateScore for each player
-	// and init empty throw splice
-	for i := range g.Base.Player {
-		score := score.BaseScore{
-			Score:        setupscore,
-			ParkScore:    setupscore,
-			InitialScore: setupscore,
-		}
-		g.Base.Player[i].Score = score
-		g.Base.Player[i].ThrowRounds = make([]throw.Round, 0)
-		g.Base.Player[i].LastThrows = make([]throw.Throw, 3)
-		g.Base.Player[i].TotalThrowCount = 0
-		g.Base.Player[i].ThrowSum = 0
-		g.Base.Player[i].Average = 0
-	}
+        // CreateScore for each player
+        // and init empty throw splice
+        for i := range g.Base.Player {
+                score := score.BaseScore{
+                        Score:        setupscore,
+                        ParkScore:    setupscore,
+                        InitialScore: setupscore,
+                }
+                g.Base.Player[i].Score = score
+                g.Base.Player[i].ThrowRounds = make([]throw.Round, 0)
+                g.Base.Player[i].LastThrows = make([]throw.Throw, 3)
+                g.Base.Player[i].TotalThrowCount = 0
+                g.Base.Player[i].ThrowSum = 0
+                g.Base.Player[i].Average = 0
+        }
 
-	sequence := g.Base.UndoLog.CreateSequence()
-	sequence.AddActionToSequence(undo.Action{
-		Action: "CREATEGAME",
-	})
+        sequence := g.Base.UndoLog.CreateSequence()
+        sequence.AddActionToSequence(undo.Action{
+                Action: "CREATEGAME",
+        })
 
-	// Update scoreboard
-	utils.WSSendUpdate(g.Base.UID, h)
+        // Update scoreboard
+        utils.WSSendUpdate(g.Base.UID, h)
 
-	return nil
+        return nil
 }
 
 // This will handle x01bust and reset game state
 func x01bust(nextState string, game *X01Game, throwRound *throw.Round, activePlayer *player.Player, sequence *undo.Sequence, previousScore int) {
-	oldState := game.Base.GameState
-	previousMessage := game.Base.Message
-	previousParkScore := activePlayer.Score.ParkScore
-	game.Base.GameState = nextState
-	switch nextState {
-	case "BUST":
-		game.Base.Message = "Bust. Remove Darts!"
-	case "BUSTNOCHECKOUT":
-		game.Base.Message = "Bust. No Checkout left. Remove Darts!"
-	case "BUSTCONDITION":
-		game.Base.Message = fmt.Sprintf("Bust. Failed Condition: %s in / %s out. Remove Darts!", game.Base.In, game.Base.Out)
-	default:
-		game.Base.Message = "-"
-	}
-	game.Base.SoundToPlay = "bust"
-	throwRound.Done = true
-	activePlayer.Score.Score = activePlayer.Score.ParkScore
-	sequence.AddActionToSequence(undo.Action{
-		Action:            "X01BUST",
-		GameID:            game.Base.UID,
-		Player:            activePlayer,
-		PreviousGameState: oldState,
-		PreviousScore:     previousScore,
-		PreviousParkScore: previousParkScore,
-		PreviousMessage:   previousMessage,
-	})
+        oldState := game.Base.GameState
+        previousMessage := game.Base.Message
+        previousParkScore := activePlayer.Score.ParkScore
+        game.Base.GameState = nextState
+        switch nextState {
+        case "BUST":
+                game.Base.Message = "Bust. Remove Darts!"
+        case "BUSTNOCHECKOUT":
+                game.Base.Message = "Bust. No Checkout left. Remove Darts!"
+        case "BUSTCONDITION":
+                game.Base.Message = fmt.Sprintf("Bust. Failed Condition: %s in / %s out. Remove Darts!", game.Base.In, game.Base.Out)
+        default:
+                game.Base.Message = "-"
+        }
+        game.Base.SoundToPlay = "bust"
+        throwRound.Done = true
+        activePlayer.Score.Score = activePlayer.Score.ParkScore
+        sequence.AddActionToSequence(undo.Action{
+                Action:            "X01BUST",
+                GameID:            game.Base.UID,
+                Player:            activePlayer,
+                PreviousGameState: oldState,
+                PreviousScore:     previousScore,
+                PreviousParkScore: previousParkScore,
+                PreviousMessage:   previousMessage,
+        })
 }
 
 // This will handle x01win
 func x01win(game *X01Game, modifier int, throwRound *throw.Round, activePlayer *player.Player, sequence *undo.Sequence) {
-	previousMessage := game.Base.Message
-	previousState := game.Base.GameState
-	previousScore := activePlayer.Score.Score
-	previousParkScore := activePlayer.Score.ParkScore
-	// Check if double or master out are met
-	if !checkoutMet(game, modifier) {
-		x01bust("BUSTCONDITION", game, throwRound, activePlayer, sequence, activePlayer.Score.Score)
-		return
-	}
-	if game.Base.Settings.Podium {
-		// Do podium and continue game
-		doPodium(&game.Base, activePlayer, sequence)
-		return
-	}
-	// Win and end game
-	doWin(&game.Base)
-	throwRound.Done = true
-	activePlayer.Score.Score = 0
-	activePlayer.Score.ParkScore = 0
+        previousMessage := game.Base.Message
+        previousState := game.Base.GameState
+        previousScore := activePlayer.Score.Score
+        previousParkScore := activePlayer.Score.ParkScore
+        // Check if double or master out are met
+        if !checkoutMet(game, modifier) {
+                x01bust("BUSTCONDITION", game, throwRound, activePlayer, sequence, activePlayer.Score.Score)
+                return
+        }
+        if game.Base.Settings.Podium {
+                // Do podium and continue game
+                doPodium(&game.Base, activePlayer, sequence)
+                return
+        }
+        // Win and end game
+        doWin(&game.Base)
+        throwRound.Done = true
+        activePlayer.Score.Score = 0
+        activePlayer.Score.ParkScore = 0
 
-	sequence.AddActionToSequence(undo.Action{
-		Action:            "DOWIN",
-		GameID:            game.Base.UID,
-		PreviousGameState: previousState,
-		PreviousMessage:   previousMessage,
-		Player:            activePlayer,
-		PreviousScore:     previousScore,
-		PreviousParkScore: previousParkScore,
-	})
+        sequence.AddActionToSequence(undo.Action{
+                Action:            "DOWIN",
+                GameID:            game.Base.UID,
+                PreviousGameState: previousState,
+                PreviousMessage:   previousMessage,
+                Player:            activePlayer,
+                PreviousScore:     previousScore,
+                PreviousParkScore: previousParkScore,
+        })
 }
 
 // This will handle the normal throw routine
 func normalThrow(game *X01Game, newScore, number, modifier int, throwRound *throw.Round, activePlayer *player.Player, sequence *undo.Sequence) {
-	// For undo function
-	previousScore := activePlayer.Score.Score
-	previousParkScore := activePlayer.Score.ParkScore
-	previousAverage := activePlayer.Average
-	previousThrowSum := activePlayer.ThrowSum
-	previousLastThree := activePlayer.LastThrows
-	previousMessage := game.Base.Message
-	previousState := game.Base.GameState
+        // For undo function
+        previousScore := activePlayer.Score.Score
+        previousParkScore := activePlayer.Score.ParkScore
+        previousAverage := activePlayer.Average
+        previousThrowSum := activePlayer.ThrowSum
+        previousLastThree := activePlayer.LastThrows
+        previousMessage := game.Base.Message
+        previousState := game.Base.GameState
 
-	// Check if checkout left on double and master out
-	if !checkoutPossible(game, newScore) {
-		x01bust("BUSTNOCHECKOUT", game, throwRound, activePlayer, sequence, activePlayer.Score.Score)
-		return
-	}
-	// Check if first throw
-	if activePlayer.Score.Score == activePlayer.Score.InitialScore {
-		// Check if in condition met
-		if !checkinPossible(game, modifier) {
-			// if last throw and condition not met - bust
-			if len(throwRound.Throws) == 3 {
-				x01bust("BUSTCONDITION", game, throwRound, activePlayer, sequence, activePlayer.Score.Score)
-			}
-			return
-		}
-	}
-	// Update player score
-	activePlayer.Score.Score = newScore
-	sequence.AddActionToSequence(undo.Action{
-		Action:            "UPDATESCORE",
-		GameID:            game.Base.UID,
-		PreviousGameState: previousState,
-		PreviousMessage:   previousMessage,
-		Player:            activePlayer,
-		PreviousScore:     previousScore,
-		PreviousParkScore: previousParkScore,
-		PreviousAverage:   previousAverage,
-		PreviousThrowSum:  previousThrowSum,
-		PreviousLastThree: previousLastThree,
-	})
+        // Check if checkout left on double and master out
+        if !checkoutPossible(game, newScore) {
+                x01bust("BUSTNOCHECKOUT", game, throwRound, activePlayer, sequence, activePlayer.Score.Score)
+                return
+        }
+        // Check if first throw
+        if activePlayer.Score.Score == activePlayer.Score.InitialScore {
+                // Check if in condition met
+                if !checkinPossible(game, modifier) {
+                        // if last throw and condition not met - bust
+                        if len(throwRound.Throws) == 3 {
+                                x01bust("BUSTCONDITION", game, throwRound, activePlayer, sequence, activePlayer.Score.Score)
+                        }
+                        return
+                }
+        }
+        // Update player score
+        activePlayer.Score.Score = newScore
+        sequence.AddActionToSequence(undo.Action{
+                Action:            "UPDATESCORE",
+                GameID:            game.Base.UID,
+                PreviousGameState: previousState,
+                PreviousMessage:   previousMessage,
+                Player:            activePlayer,
+                PreviousScore:     previousScore,
+                PreviousParkScore: previousParkScore,
+                PreviousAverage:   previousAverage,
+                PreviousThrowSum:  previousThrowSum,
+                PreviousLastThree: previousLastThree,
+        })
 
-	// Check if x01 specific sound has to be played
-	if modifier == 3 {
-		switch number {
-		case 17:
-			game.Base.SoundToPlay = "T17"
-		case 18:
-			game.Base.SoundToPlay = "T18"
-		case 19:
-			game.Base.SoundToPlay = "T19"
-		case 20:
-			game.Base.SoundToPlay = "T20"
-		default:
-		}
-	} else if modifier == 2 {
-		if number == 25 {
-			game.Base.SoundToPlay = "D25"
-		}
-	} else if modifier == 0 || number == 0 {
-		game.Base.SoundToPlay = "miss"
-	} else {
-		game.Base.SoundToPlay = "none"
-	}
+        // Check if x01 specific sound has to be played
+        if modifier == 3 {
+                switch number {
+                case 17:
+                        game.Base.SoundToPlay = "T17"
+                case 18:
+                        game.Base.SoundToPlay = "T18"
+                case 19:
+                        game.Base.SoundToPlay = "T19"
+                case 20:
+                        game.Base.SoundToPlay = "T20"
+                default:
+                }
+        } else if modifier == 2 {
+                if number == 25 {
+                        game.Base.SoundToPlay = "D25"
+                }
+        } else if modifier == 0 || number == 0 {
+                game.Base.SoundToPlay = "miss"
+        } else {
+                game.Base.SoundToPlay = "none"
+        }
 
-	// Check if 3 throws in round and close round
-	// Also set gameState and perhaps increase game.Base.ThrowRound
-	// if everyone has already thrown to this round
-	if len(throwRound.Throws) == 3 {
-		activePlayer.Score.Score = newScore
-		activePlayer.Score.ParkScore = newScore
-		closePlayerRound(&game.Base, activePlayer, throwRound, sequence, []undo.Action{
-			{
-				Action:            "UPDATESCOREANDPARK",
-				Player:            activePlayer,
-				PreviousScore:     previousScore,
-				PreviousParkScore: previousParkScore,
-				PreviousAverage:   previousAverage,
-				PreviousThrowSum:  previousThrowSum,
-				PreviousLastThree: previousLastThree,
-			},
-		}, previousState, previousMessage)
-	}
+        // Check if 3 throws in round and close round
+        // Also set gameState and perhaps increase game.Base.ThrowRound
+        // if everyone has already thrown to this round
+        if len(throwRound.Throws) == 3 {
+                activePlayer.Score.Score = newScore
+                activePlayer.Score.ParkScore = newScore
+                closePlayerRound(&game.Base, activePlayer, throwRound, sequence, []undo.Action{
+                        {
+                                Action:            "UPDATESCOREANDPARK",
+                                Player:            activePlayer,
+                                PreviousScore:     previousScore,
+                                PreviousParkScore: previousParkScore,
+                                PreviousAverage:   previousAverage,
+                                PreviousThrowSum:  previousThrowSum,
+                                PreviousLastThree: previousLastThree,
+                        },
+                }, previousState, previousMessage)
+        }
 }
 
 // This will check if a checkout is even possible anymore and return a bool
 func checkoutPossible(game *X01Game, newScore int) bool {
-	if game.Base.Out != "straight" {
-		return newScore != 1
-	}
-	return true
+        if game.Base.Out != "straight" {
+                return newScore != 1
+        }
+        return true
 }
 
 // This will check if the checkout condition is met and return bool
 func checkoutMet(game *X01Game, modifier int) bool {
-	if game.Base.Out == "double" {
-		return modifier == 2
-	} else if game.Base.Out == "master" {
-		return modifier != 1
-	}
-	return true
+        if game.Base.Out == "double" {
+                return modifier == 2
+        } else if game.Base.Out == "master" {
+                return modifier != 1
+        }
+        return true
 }
 
 // This will check if a checkin is possible and return a bool
 func checkinPossible(game *X01Game, modifier int) bool {
-	if game.Base.In == "double" {
-		return modifier == 2
-	} else if game.Base.In == "master" {
-		return modifier != 1
-	}
-	return true
+        if game.Base.In == "double" {
+                return modifier == 2
+        } else if game.Base.In == "master" {
+                return modifier != 1
+        }
+        return true
 }


### PR DESCRIPTION
This pull request addresses two issues:

1. Fixes syntax errors in the `GetStatus()` method for game types
2. Adds proper handling of the `EndTime` field when a game is won

Changes include:
- Correcting syntax in `GetStatus()` methods
- Setting `EndTime` to the current time when a game reaches the WON state
- Adding JSON serialization support for the `EndTime` field